### PR TITLE
Modified NuGet.config to override the global NuGet.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -14,4 +14,8 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <!-- This is used to override the global NuGet.config and enable nuget.org -->
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Modified the NuGet.config to override the behavior of the global NuGet.config on the machine. There are cases where nuget.org is disabled globally for example, and packages won't be restored.