### PR TITLE
Add not null attributes for code analysis purposes in validation code

### DIFF
--- a/src/System/Validation/Code.cs
+++ b/src/System/Validation/Code.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <exception cref="ArgumentException">Thrown if any argument  <paramref name="argumentValue"/> element is null.</exception>
 		/// <exception cref="ArgumentNullException">Thrown if the supplied argument <paramref name="argumentValue"/> is null.</exception>
-		public static IEnumerable<T> ExpectsAllNotNull<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static IEnumerable<T> ExpectsAllNotNull<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 			where T : class
 		{
 			argumentValue = ExpectsArgument(argumentValue, argumentName, tagId);
@@ -63,7 +63,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <exception cref="ArgumentException">Thrown if the argument <paramref name="argumentValue"/> is empty.</exception>
 		/// <exception cref="ArgumentNullException">Thrown if the supplied argument <paramref name="argumentValue"/> is null.</exception>
-		public static IEnumerable<T> ExpectsAny<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static IEnumerable<T> ExpectsAny<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 		{
 			argumentValue = ExpectsArgument(argumentValue, argumentName, tagId);
 
@@ -84,7 +84,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <typeparam name="T">Type of argument to validate</typeparam>
 		/// <exception cref="ArgumentNullException">Thrown if the supplied argument <paramref name="argumentValue"/> is null.</exception>
-		public static T ExpectsArgument<T>(T argumentValue, string argumentName, uint? tagId)
+		public static T ExpectsArgument<T>([ValidatedNotNull] T argumentValue, string argumentName, uint? tagId)
 		{
 			if (!ValidateArgument(argumentValue, argumentName, tagId))
 			{
@@ -124,7 +124,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <exception cref="ArgumentException">Thrown if the argument <paramref name="argumentValue"/> is empty or contains only whitespace.</exception>
 		/// <exception cref="ArgumentNullException">Thrown if the supplied argument <paramref name="argumentValue"/> is null.</exception>
-		public static string ExpectsNotNullOrWhiteSpaceArgument(string argumentValue, string argumentName, uint? tagId)
+		public static string ExpectsNotNullOrWhiteSpaceArgument([ValidatedNotNull] string argumentValue, string argumentName, uint? tagId)
 		{
 			argumentValue = ExpectsArgument(argumentValue, argumentName, tagId);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag identifier to log; leave null if no logging is required.</param>
 		/// <returns>Returns the argument value as is if validation succeeds, otherwise an exception is thrown.</returns>
 		/// <exception cref="ArgumentNullException">Thrown if the supplied argument <paramref name="argumentValue"/> is null.</exception>
-		public static T ExpectsObject<T>(T argumentValue, string argumentName, uint? tagId) where T : class
+		public static T ExpectsObject<T>([ValidatedNotNull] T argumentValue, string argumentName, uint? tagId) where T : class
 		{
 			return ExpectsArgument<T>(argumentValue, argumentName, tagId);
 		}
@@ -207,7 +207,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null and contains only non-null elements; false otherwise.</returns>
-		public static bool ValidateAllNotNull<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateAllNotNull<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 			where T : class
 		{
 			if (!ValidateArgument(argumentValue, argumentName, tagId))
@@ -238,7 +238,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null and contains at least one element; false otherwise.</returns>
 		/// <typeparam name="T">The element type.</typeparam>
-		public static bool ValidateAny<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateAny<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 		{
 			if (!ValidateArgument(argumentValue, argumentName, tagId))
 			{
@@ -267,7 +267,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null; false otherwise.</returns>
-		public static bool ValidateArgument(object argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateArgument([ValidatedNotNull] object argumentValue, string argumentName, uint? tagId)
 		{
 			if (argumentValue == null)
 			{
@@ -342,7 +342,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">The argument name.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null, empty or only whitespace; false otherwise.</returns>
-		public static bool ValidateNotNullOrWhiteSpaceArgument(string argumentValue, string argumentName, uint? tagId = null)
+		public static bool ValidateNotNullOrWhiteSpaceArgument([ValidatedNotNull] string argumentValue, string argumentName, uint? tagId = null)
 		{
 			if (string.IsNullOrWhiteSpace(argumentValue))
 			{

--- a/src/System/Validation/Code.cs
+++ b/src/System/Validation/Code.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null and contains only non-null elements; false otherwise.</returns>
-		public static bool ValidateAllNotNull<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateAllNotNull<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 			where T : class
 		{
 			if (!ValidateArgument(argumentValue, argumentName, tagId))
@@ -238,7 +238,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null and contains at least one element; false otherwise.</returns>
 		/// <typeparam name="T">The element type.</typeparam>
-		public static bool ValidateAny<T>([ValidatedNotNull] IEnumerable<T> argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateAny<T>(IEnumerable<T> argumentValue, string argumentName, uint? tagId)
 		{
 			if (!ValidateArgument(argumentValue, argumentName, tagId))
 			{
@@ -267,7 +267,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null; false otherwise.</returns>
-		public static bool ValidateArgument([ValidatedNotNull] object argumentValue, string argumentName, uint? tagId)
+		public static bool ValidateArgument(object argumentValue, string argumentName, uint? tagId)
 		{
 			if (argumentValue == null)
 			{
@@ -342,7 +342,7 @@ namespace Microsoft.Omex.System.Validation
 		/// <param name="argumentName">The argument name.</param>
 		/// <param name="tagId">Tag Id to log, leave null if no logging is needed</param>
 		/// <returns>True if the argument <paramref name="argumentValue"/> is not null, empty or only whitespace; false otherwise.</returns>
-		public static bool ValidateNotNullOrWhiteSpaceArgument([ValidatedNotNull] string argumentValue, string argumentName, uint? tagId = null)
+		public static bool ValidateNotNullOrWhiteSpaceArgument(string argumentValue, string argumentName, uint? tagId = null)
 		{
 			if (string.IsNullOrWhiteSpace(argumentValue))
 			{

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -16,17 +16,16 @@ namespace Microsoft.Omex.System.Validation
 	/// </summary>
 	/// <example>
 	/// In this example the Guard.NotNull has the attribute present on its parameter. If it wasn't present the analyzer would not know
-	/// that s cannot be null following the execution of the method, resulting in a warning on the execution of the `.toUpper` method.
+	/// that s cannot be null following the execution of the method, resulting in a warning on the execution of the <c>toUpperInvariant</c> method.
 	/// <code>
 	/// string s = mightBeNullClass?.stringProperty;
 	///
 	/// Guard.NotNull(s);
 	///
 	/// // The analyzer now knows `s` will never be null here
-	/// return s.toUpper();
+	/// return s.toUpperInvariant();
 	/// </code>
 	/// </example>
-	/// 
 	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
 	internal sealed class ValidatedNotNullAttribute : Attribute { }
 }

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -6,17 +6,18 @@ using System;
 namespace Microsoft.Omex.System.Validation
 {
 	/// <summary>
-	/// Indicates to Code analysis tools that a method validates a particular parameter to not be null.
+	/// Indicates to code analysis tools that a method validates a particular parameter to not be null.
 	/// 
 	/// This can for instance be used to suppress VS design warning CA1062 (validate public method parameters before use) by applying to
-	/// external validation libraries, such as the `Code` class in this project.
+	/// external validation libraries, such as the <see cref="Code" /> class in this project.
 	/// 
 	/// If an attribute with the name ValidatedNotNull is present on the parameter of the validation method it tells the analyzer that the 
 	/// parameter will never be null in the code path following the execution of that method.
 	/// </summary>
 	/// <example>
-	/// In this example the Guard.NotNull has the attribute present on its parameter. If it wasn't present the analyzer would not know
-	/// that s cannot be null following the execution of the method, resulting in a warning on the execution of the <c>toUpperInvariant</c> method.
+	/// In this example the <c>Guard.NotNull</c> has the attribute present on its parameter. If it wasn't present the analyzer would not know
+	/// that <c>s</c> cannot be <c>null</c> following the execution of the method, resulting in a warning on the execution of the
+	/// <c>toUpperInvariant</c> method.
 	/// <code>
 	/// string s = mightBeNullClass?.stringProperty;
 	///

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.Omex.System.Validation
+{
+    /// <summary>
+    /// Indicates to Code analysis tools that a method validates a particular parameter to not be null
+    /// </summary>
+    internal sealed class ValidatedNotNullAttribute : Attribute {}
+}

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -6,8 +6,27 @@ using System;
 namespace Microsoft.Omex.System.Validation
 {
 	/// <summary>
-	/// Indicates to Code analysis tools that a method validates a particular parameter to not be null
+	/// Indicates to Code analysis tools that a method validates a particular parameter to not be null.
+	/// 
+	/// This can for instance be used to suppress VS design warning CA1062 (validate public method parameters before use) by applying to
+	/// external validation libraries, such as the `Code` class in this project.
+	/// 
+	/// If an attribute with the name ValidatedNotNull is present on the parameter of the validation method it tells the analyzer that the 
+	/// parameter will never be null in the code path following the execution of that method.
 	/// </summary>
+	/// <example>
+	/// In this example the Guard.NotNull has the attribute present on its parameter. If it wasn't present the analyzer would not know
+	/// that s cannot be null following the execution of the method, resulting in a warning on the execution of the `.toUpper` method.
+	/// <code>
+	/// string s = mightBeNullClass?.stringProperty;
+	///
+	/// Guard.NotNull(s);
+	///
+	/// // The analyzer now knows `s` will never be null here
+	/// return s.toUpper();
+	/// </code>
+	/// </example>
+	/// 
 	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
 	internal sealed class ValidatedNotNullAttribute : Attribute { }
 }

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Omex.System.Validation
     /// <summary>
     /// Indicates to Code analysis tools that a method validates a particular parameter to not be null
     /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     internal sealed class ValidatedNotNullAttribute : Attribute {}
 }

--- a/src/System/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System/Validation/ValidatedNotNullAttribute.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Microsoft.Omex.System.Validation
 {
-    /// <summary>
-    /// Indicates to Code analysis tools that a method validates a particular parameter to not be null
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    internal sealed class ValidatedNotNullAttribute : Attribute {}
+	/// <summary>
+	/// Indicates to Code analysis tools that a method validates a particular parameter to not be null
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+	internal sealed class ValidatedNotNullAttribute : Attribute { }
 }


### PR DESCRIPTION
In order to suppress [CA1062](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods?view=vs-2019) when using external validation libraries, e.g. this library, you need to decorate the validated params with a ValidatedNotNullAttribute in order for the compiler to understand that the method in fact checks for null.

- Created the ValidatedNotNullAttribute 
- Added the ValidatedNotNullAttribute to the Validation methods that checks for null