### PR TITLE
Fix dotnet framework version for gategen so it is always net45

### DIFF
--- a/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.csproj
+++ b/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
     <Description>Contains Omex Gating generator code</Description>
     <RootNamespace>Microsoft.Omex.CodeGenerators.GateGen</RootNamespace>
     <AssemblyName>Microsoft.Omex.CodeGenerators.GateGen</AssemblyName>

--- a/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
+++ b/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
@@ -26,7 +26,7 @@
 		<Error Text="The TipXml property is not defined." Condition="'$(TipXml)' == ''" />
 		<Error Text="The GeneratedGates property is not defined." Condition="'$(GeneratedGates)' == ''" />
 
-		<Exec Command="$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Omex.CodeGenerators.GateGen.exe $(GatesXml) $(TipXml) $(GeneratedGates) $(OmexGatesNamespace)" />
+		<Exec Command="$(MSBuildThisFileDirectory)..\lib\net45\Microsoft.Omex.CodeGenerators.GateGen.exe $(GatesXml) $(TipXml) $(GeneratedGates) $(OmexGatesNamespace)" />
 		
 		<CreateItem Include="$(GeneratedGates)">
 			<Output TaskParameter="Include" ItemName="Compile"/>


### PR DESCRIPTION
Fix dotnet framework version for gategen so it is always net45 (it doesn't need any particular framework so this is as good a choice as any)