### PR TITLE
ICorrelationDataProvider injection in constructor to match the registration.

### DIFF
--- a/src/System/Diagnostics/BasicMachineInformation.cs
+++ b/src/System/Diagnostics/BasicMachineInformation.cs
@@ -149,9 +149,9 @@ namespace Microsoft.Omex.System.Diagnostics
 		}, LazyThreadSafetyMode.PublicationOnly);
 
 
-        /// <summary>
-        /// The default empty value
-        /// </summary>
-        protected const string DefaultEmptyValue = "None";
+		/// <summary>
+		/// The default empty value
+		/// </summary>
+		protected const string DefaultEmptyValue = "None";
 	}
 }

--- a/src/System/TimedScopes/ReplayEventLogging/ReplayEventConfigurator.cs
+++ b/src/System/TimedScopes/ReplayEventLogging/ReplayEventConfigurator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Omex.System.TimedScopes.ReplayEventLogging
 		private IReplayEventDisabledTimedScopes DisabledTimedScopes { get; }
 
 
-		private Correlation Correlation { get; }
+		private ICorrelationDataProvider Correlation { get; }
 
 
 		/// <summary>
@@ -22,7 +22,7 @@ namespace Microsoft.Omex.System.TimedScopes.ReplayEventLogging
 		/// </summary>
 		/// <param name="disabledTimedScopes">Disabled timed scopes</param>
 		/// <param name="correlation">Correlation</param>
-		public ReplayEventConfigurator(IReplayEventDisabledTimedScopes disabledTimedScopes, Correlation correlation)
+		public ReplayEventConfigurator(IReplayEventDisabledTimedScopes disabledTimedScopes, ICorrelationDataProvider correlation)
 		{
 			Code.ExpectsArgument(disabledTimedScopes, nameof(disabledTimedScopes), TaggingUtilities.ReserveTag(0x23817714 /* tag_96x2u */));
 			Code.ExpectsArgument(correlation, nameof(correlation), TaggingUtilities.ReserveTag(0x23817715 /* tag_96x2v */));


### PR DESCRIPTION
Fixing Correlation class injection, looks like we're injecting concrete while registration is interface.