### PR TITLE
Change DataListener to enable creation of standard activities

### DIFF
--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			ActivityStartEnding,
 			ActivityStopEnding,
 			// We need to listen for the "Microsoft.AspNetCore.Hosting.HttpRequestIn" event in order to signal Kestrel to create an Activity for the incoming http request.
-			// searching of for RequestIn in case any other requests follow the same pattern
+			// Searching only for RequestIn, in case any other requests follow the same pattern
 			"RequestIn",
 			// we need to listen for "System.Net.Http.HttpRequestOut" to create activity for outgoing http requests
 			// searching only for RequestOut in case any other requests follow the same pattern

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 		private static readonly string[] s_eventEndMarkersToListen = new[] {
 			ActivityStartEnding,
 			ActivityStopEnding,
-			// we need to listen for "Microsoft.AspNetCore.Hosting.HttpRequestIn" event in order singnal Kestrel to create Activity for incoming http request
+			// We need to listen for the "Microsoft.AspNetCore.Hosting.HttpRequestIn" event in order to signal Kestrel to create an Activity for the incoming http request.
 			// searching of for RequestIn in case any other requests follow the same pattern
 			"RequestIn",
 			// we need to listen for "System.Net.Http.HttpRequestOut" to create activity for outgoing http requests

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -14,9 +14,15 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 {
 	internal sealed class ActivityObserversIntializer : IHostedService, IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object>>
 	{
-		private const string ActivityStartEnding = ".Start";
+		/// <summary>
+		/// Ending of the Activity Start event
+		/// </summary>
+		internal static readonly string ActivityStartEnding = ".Start";
 
-		private const string ActivityStopEnding = ".Stop";
+		/// <summary>
+		/// Ending of the Activity Stop event
+		/// </summary>
+		internal static readonly string ActivityStopEnding = ".Stop";
 
 		private static readonly string[] s_eventEndMarkersToListen = new[] {
 			ActivityStartEnding,
@@ -28,6 +34,22 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			// Searching only for RequestOut, in case any other requests follow the same pattern
 			"RequestOut",
 		};
+
+		private static bool EventEndsWith(string eventName, string ending) => eventName.EndsWith(ending, StringComparison.Ordinal);
+
+		private static bool IsEnabled(string eventName)
+		{
+			// Using foreach instead of Any to avoid creating closure since this method is called very often
+			foreach (string ending in s_eventEndMarkersToListen)
+			{
+				if (EventEndsWith(eventName, ending))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
 
 		private readonly IActivityStartObserver[] m_activityStartObservers;
 		private readonly IActivityStopObserver[] m_activityStopObservers;
@@ -58,22 +80,6 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 
 			m_observerLifetime?.Dispose();
 			return Task.CompletedTask;
-		}
-
-		private bool EventEndsWith(string eventName, string ending) => eventName.EndsWith(ending, StringComparison.Ordinal);
-
-		private bool IsEnabled(string eventName)
-		{
-			// Using foreach instead of Any to avoid creating closure since this method is called very often
-			foreach (string ending in s_eventEndMarkersToListen)
-			{
-				if (EventEndsWith(eventName, ending))
-				{
-					return true;
-				}
-			}
-
-			return false;
 		}
 
 		void IObserver<DiagnosticListener>.OnCompleted() { }

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			}
 			else if (EventEndsWith(eventName, ActivityStopEnding))
 			{
-				OnActivityStoped(activity, value.Value);
+				OnActivityStopped(activity, value.Value);
 			}
 		}
 
@@ -115,7 +115,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			}
 		}
 
-		private void OnActivityStoped(Activity activity, object payload)
+		private void OnActivityStopped(Activity activity, object payload)
 		{
 			foreach (IActivityStopObserver stopHandler in m_activityStopObservers)
 			{

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 
 		private bool IsEnabled(string eventName)
 		{
-			// using foreach instead of Any to avoid creating closure since this method called very often
+			// Using foreach instead of Any to avoid creating closure since this method is called very often
 			foreach (string ending in s_eventEndMarkersToListen)
 			{
 				if (EventEndsWith(eventName, ending))

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			// Searching only for RequestIn, in case any other requests follow the same pattern
 			"RequestIn",
 			// We need to listen for the "System.Net.Http.HttpRequestOut" event in order to create an Activity for the outgoing http requests.
-			// searching only for RequestOut in case any other requests follow the same pattern
+			// Searching only for RequestOut, in case any other requests follow the same pattern
 			"RequestOut",
 		};
 

--- a/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
+++ b/src/Extensions/TimedScopes/Internal/ActivityObserversIntializer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			// We need to listen for the "Microsoft.AspNetCore.Hosting.HttpRequestIn" event in order to signal Kestrel to create an Activity for the incoming http request.
 			// Searching only for RequestIn, in case any other requests follow the same pattern
 			"RequestIn",
-			// we need to listen for "System.Net.Http.HttpRequestOut" to create activity for outgoing http requests
+			// We need to listen for the "System.Net.Http.HttpRequestOut" event in order to create an Activity for the outgoing http requests.
 			// searching only for RequestOut in case any other requests follow the same pattern
 			"RequestOut",
 		};

--- a/tests/Extensions/TimedScopes.UnitTests/ActivityObserversIntializerTests.cs
+++ b/tests/Extensions/TimedScopes.UnitTests/ActivityObserversIntializerTests.cs
@@ -57,9 +57,9 @@ namespace Hosting.Services.UnitTests
 		private void AssertEnabledFor(DiagnosticListener listener, string eventName) =>
 			Assert.IsTrue(listener.IsEnabled(eventName), "Should be enabled for '{0}'", eventName);
 
-		private string MakeStartName(string name) => name + ".Start";
+		private string MakeStartName(string name) => name + ActivityObserversIntializer.ActivityStartEnding;
 
-		private string MakeStopName(string name) => name + ".Stop";
+		private string MakeStopName(string name) => name + ActivityObserversIntializer.ActivityStopEnding;
 
 		private const string HttpRequestOutEventName = "System.Net.Http.HttpRequestOut";
 

--- a/tests/Extensions/TimedScopes.UnitTests/ActivityObserversIntializerTests.cs
+++ b/tests/Extensions/TimedScopes.UnitTests/ActivityObserversIntializerTests.cs
@@ -30,9 +30,13 @@ namespace Hosting.Services.UnitTests
 
 				using DiagnosticListener listener = new DiagnosticListener(name);
 
-				Assert.IsTrue(listener.IsEnabled(MakeStartName(name)), "Should be enabled for Activity.Start");
+				AssertEnabledFor(listener, HttpRequestOutEventName);
+				AssertEnabledFor(listener, HttpRequestInEventName);
+
+				AssertEnabledFor(listener, MakeStartName(name));
+				AssertEnabledFor(listener, MakeStopName(name));
+
 				Assert.IsFalse(listener.IsEnabled(name, "Should be disabled for other events"));
-				Assert.IsTrue(listener.IsEnabled(MakeStopName(name)), "Should be enabled for Activity.Stop");
 
 				Activity activity = new Activity(name);
 				object obj = new object();
@@ -50,8 +54,15 @@ namespace Hosting.Services.UnitTests
 			}
 		}
 
+		private void AssertEnabledFor(DiagnosticListener listener, string eventName) =>
+			Assert.IsTrue(listener.IsEnabled(eventName), "Should be enabled for '{0}'", eventName);
+
 		private string MakeStartName(string name) => name + ".Start";
 
 		private string MakeStopName(string name) => name + ".Stop";
+
+		private const string HttpRequestOutEventName = "System.Net.Http.HttpRequestOut";
+
+		private const string HttpRequestInEventName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
 	}
 }


### PR DESCRIPTION
DataListener needs to lister special events to enable creation of standard activities for requests.