### PR TITLE
Fix folder name for Abstraction package

### DIFF
--- a/src/Extensions/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Extensions/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="BuildTransitive\*" Pack="true" PackagePath="build" />
+    <Content Include="BuildTransitive\*" Pack="true" PackagePath="buildTransitive" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(Microsoft_Extensions_Logging_Abstractions_Version)" />


### PR DESCRIPTION
Fix folder name for Abstraction package since `build` will be included only to the package that uses it directly