### PR TITLE
Swicth from BackgroundService to IHostedService (and typo fixes)

### DIFF
--- a/src/Extensions/Abstractions/Accessors/Accessor.cs
+++ b/src/Extensions/Abstractions/Accessors/Accessor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.Accessors
 	/// <summary>
 	/// Type for accessing an object that is not available during dependency injection container creation
 	/// </summary>
-	/// <typeparam name="TValue">Type that will be accessable after dependency injection creation</typeparam>
+	/// <typeparam name="TValue">Type that will be accessible after dependency injection creation</typeparam>
 	public class Accessor<TValue> : IAccessor<TValue>, IAccessorSetter<TValue>
 		where TValue : class
 	{

--- a/src/Extensions/Abstractions/Activities/Processing/ActivityResultStrings.cs
+++ b/src/Extensions/Abstractions/Activities/Processing/ActivityResultStrings.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Omex.Extensions.Abstractions.Activities.Processing
 {
 	/// <summary>
-	/// Class with activity result enum string values to avoid alocations
+	/// Class with activity result enum string values to avoid allocations
 	/// </summary>
 	public static class ActivityResultStrings
 	{

--- a/src/Extensions/Abstractions/Activities/TimedScope.cs
+++ b/src/Extensions/Abstractions/Activities/TimedScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 	/// <summary>
 	/// Logs duration of activity
 	/// </summary>
-	/// <remarks>This class will be replaced with Activity after move to net 5, since it will be trackable and disposable</remarks>
+	/// <remarks>This class will be replaced with Activity after move to net 5, since it will be traceable and disposable</remarks>
 	public class TimedScope : IDisposable
 	{
 		/// <summary>

--- a/src/Extensions/Abstractions/Tag.cs
+++ b/src/Extensions/Abstractions/Tag.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Omex.Extensions.Abstractions
 {
 	/// <summary>
-	/// Tagging utitilty class
+	/// Tagging utility class
 	/// </summary>
 	public static class Tag
 	{

--- a/src/Extensions/Compatibility/OmexCompatibilityIntializer.cs
+++ b/src/Extensions/Compatibility/OmexCompatibilityIntializer.cs
@@ -14,12 +14,12 @@ using Microsoft.Omex.Extensions.Compatibility.Validation;
 namespace Microsoft.Omex.Extensions.Compatibility
 {
 	/// <summary>
-	/// Class to initialize static depdencies from this project
+	/// Class to initialize static dependencies from this project
 	/// </summary>
 	public static class OmexCompatibilityIntializer
 	{
 		/// <summary>
-		/// Initialize compatablitity classes with provided instances
+		/// Initialize compatibility classes with provided instances
 		/// </summary>
 		public static void Initialize(ILoggerFactory factory, ITimedScopeProvider scopeProvider)
 		{
@@ -29,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Compatibility
 		}
 
 		/// <summary>
-		/// Initialize compatablitity classes with simple implementation that might be used for logging
+		/// Initialize compatibility classes with simple implementation that might be used for logging
 		/// </summary>
 		public static void InitializeWithStubs() =>
 			Initialize(new NullLoggerFactory(), new SimpleScopeProvider());

--- a/src/Extensions/Hosting.Services.Remoting/HostBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services.Remoting/HostBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 	public static class HostBuilderExtensions
 	{
 		/// <summary>
-		/// Adds remote listener to statefull service
+		/// Adds remote listener to stateful service
 		/// </summary>
 		public static ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> AddRemotingListener<TService>(
 			this ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> builder,
@@ -39,7 +39,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 					builder.AddRemotingListener(name, (provider, _) => provider.GetService<TService>(), settings);
 
 		/// <summary>
-		/// Adds remote listener to statefull service
+		/// Adds remote listener to stateful service
 		/// </summary>
 		public static ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> AddRemotingListener<TListener>(
 			this ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> builder)

--- a/src/Extensions/Hosting.Services.Web/ApplicationBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services.Web/ApplicationBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web
 		/// Adds the default exception handling logic that will display a developer exception page in develop and a short message during deployment
 		/// </summary>
 		/// <param name="builder">Application builder</param>
-		/// <param name="environment">Enviroment information</param>
+		/// <param name="environment">Environment information</param>
 		/// <param name="enableCorrelationHeaderBackwardCompatibility">Set it to true if the service needs to accept a request with old style correlation</param>
 		public static IApplicationBuilder UseOmexMiddlewares(
 			this IApplicationBuilder builder,
@@ -90,7 +90,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web
 							{ "Message", "Internal Server Error" },
 							{ "ErrorMessage", contextFeature?.Error?.Message ?? string.Empty },
 							{ "RequestId", Activity.Current?.Id ?? context.TraceIdentifier },
-							{ "Suggestion", "For local debugging, set ASPNETCORE_ENVIRONMENT environment variable to 'Development' and restart the app" }
+							{ "Suggestion", "For local debugging, set ASPNETCORE_ENVIRONMENT environment variable to 'Development' and restart the application" }
 						};
 
 						return context.Response.WriteAsync(JsonSerializer.Serialize(errorDict));

--- a/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	/// <remarks>
 	/// This middleware should be removed after all services moved to use <see cref="Activity"/>
 	/// </remarks>
-	[Obsolete("Use it only if you need to comunicate with services that use old correlation", false)]
+	[Obsolete("Use it only if you need to communicate with services that use old correlation", false)]
 	internal class ObsoleteCorrelationHeadersMiddleware : IMiddleware
 	{
 		Task IMiddleware.InvokeAsync(HttpContext context, RequestDelegate next)
@@ -95,7 +95,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		private static bool IsClientRequest(HttpRequest request) =>
 			request.Headers.ContainsKey(OfficeClientVersionHeader)
 				? true
-				: request.Query.Count == 0 // Don't check empty params
+				: request.Query.Count == 0 // Don't check empty parameters
 					? false
 					: s_officeClientQueryParameters.Any(p => request.Query.ContainsKey(p)); // Check if the request contains an Office client query parameter
 

--- a/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 	public static class HostBuilderExtensions
 	{
 		/// <summary>
-		/// Configures host to run service fabric stateless service with initializded Omex dependencies
+		/// Configures host to run service fabric stateless service with initialized Omex dependencies
 		/// </summary>
 		public static IHost BuildStatelessService(
 			this IHostBuilder builder,
@@ -32,7 +32,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 				builder.BuildServiceFabricService<OmexStatelessServiceRegistrator, OmexStatelessService, StatelessServiceContext>(serviceName, builderAction);
 
 		/// <summary>
-		/// Configures host to run service fabric stateful service with initializded Omex dependencies
+		/// Configures host to run service fabric stateful service with initialized Omex dependencies
 		/// </summary>
 		public static IHost BuildStatefulService(
 			this IHostBuilder builder,
@@ -75,7 +75,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			{
 				if (string.IsNullOrWhiteSpace(serviceName))
 				{
-					// use executing asembly name for loggins since application name might be not available yet
+					// use executing assembly name for logging since application name not available
 					serviceNameForLogging = Assembly.GetExecutingAssembly().GetName().FullName;
 					throw new ArgumentException("Service type name is null of whitespace", nameof(serviceName));
 				}
@@ -115,7 +115,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		}
 
 		/// <summary>
-		/// Overides ApplicationName in host configuration
+		/// Overrides ApplicationName in host configuration
 		/// </summary>
 		/// <remarks>
 		/// Method done internal instead of private to create unit tests for it,

--- a/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			this IHostBuilder builder,
 			string serviceName,
 			Action<ServiceFabricHostBuilder<OmexStatelessService, StatelessServiceContext>> builderAction) =>
-				builder.BuildServiceFabricService<OmexStatelessServiceRunner, OmexStatelessService, StatelessServiceContext>(serviceName, builderAction);
+				builder.BuildServiceFabricService<OmexStatelessServiceRegistrator, OmexStatelessService, StatelessServiceContext>(serviceName, builderAction);
 
 		/// <summary>
 		/// Configures host to run service fabric stateful service with initializded Omex dependencies
@@ -38,7 +38,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			this IHostBuilder builder,
 			string serviceName,
 			Action<ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext>> builderAction) =>
-				builder.BuildServiceFabricService<OmexStatefulServiceRunner, OmexStatefulService, StatefulServiceContext>(serviceName, builderAction);
+				builder.BuildServiceFabricService<OmexStatefulServiceRegistrator, OmexStatefulService, StatefulServiceContext>(serviceName, builderAction);
 
 		/// <summary>
 		/// Registering Dependency Injection classes that will provide Service Fabric specific information for logging
@@ -65,7 +65,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			this IHostBuilder builder,
 			string serviceName,
 			Action<ServiceFabricHostBuilder<TService, TContext>> builderAction)
-				where TRunner : OmexServiceRunner<TService, TContext>
+				where TRunner : OmexServiceRegistrator<TService, TContext>
 				where TService : IServiceFabricService<TContext>
 				where TContext : ServiceContext
 		{
@@ -90,7 +90,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 					{
 						collection
 							.AddOmexServiceFabricDependencies<TContext>()
-							.AddSingleton<IOmexServiceRunner, TRunner>()
+							.AddSingleton<IOmexServiceRegistrator, TRunner>()
 							.AddHostedService<OmexHostedService>();
 					})
 					.UseDefaultServiceProvider(options =>

--- a/src/Extensions/Hosting.Services/IListenerBuilder.cs
+++ b/src/Extensions/Hosting.Services/IListenerBuilder.cs
@@ -7,7 +7,7 @@ using Microsoft.ServiceFabric.Services.Communication.Runtime;
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
 	/// <summary>
-	/// Creates comunication listener for SF service
+	/// Creates communication listener for SF service
 	/// </summary>
 	public interface IListenerBuilder<in TService>
 		where TService : IServiceFabricService<ServiceContext>
@@ -18,7 +18,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		string Name { get; }
 
 		/// <summary>
-		/// Creates comunication listener for SF service
+		/// Creates communication listener for SF service
 		/// </summary>
 		ICommunicationListener Build(TService service);
 	}

--- a/src/Extensions/Hosting.Services/IServiceAction.cs
+++ b/src/Extensions/Hosting.Services/IServiceAction.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
 	/// <summary>
-	/// Action that will be executed in RunAsync methond of SF service
+	/// Action that will be executed in RunAsync method of SF service
 	/// </summary>
 	public interface IServiceAction<in TService>
 		where TService : IServiceFabricService<ServiceContext>
 	{
 		/// <summary>
-		/// Action that will be executed in RunAsync methond of SF service
+		/// Action that will be executed in RunAsync method of SF service
 		/// </summary>
 		Task RunAsync(TService service, CancellationToken cancellationToken);
 	}

--- a/src/Extensions/Hosting.Services/Internal/IOmexServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/IOmexServiceRegistrator.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 {
 	internal interface IOmexServiceRegistrator
 	{
-		Task RegisterServiceAsync(CancellationToken cancellationToken);
+		Task RegisterAsync(CancellationToken cancellationToken);
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/IOmexServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/IOmexServiceRegistrator.cs
@@ -9,8 +9,8 @@ using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
-	internal interface IOmexServiceRunner
+	internal interface IOmexServiceRegistrator
 	{
-		Task RunServiceAsync(CancellationToken cancellationToken);
+		Task RegisterServiceAsync(CancellationToken cancellationToken);
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		{
 			if (task.IsFaulted)
 			{
-				m_logger.LogCritical(Tag.Create(), task.Exception, "Service registration stoped due to exeption");
+				m_logger.LogCritical(Tag.Create(), task.Exception, "Service registration stopped due to exception");
 			}
 			else if (task.IsCanceled)
 			{

--- a/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		{
 			try
 			{
-				await m_runner.RegisterServiceAsync(m_tokenSource.Token).ConfigureAwait(false);
+				await m_runner.RegisterAsync(m_tokenSource.Token).ConfigureAwait(false);
 
 				m_logger.LogInformation(Tag.Create(), "ServiceFabricHost initialized");
 			}

--- a/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexHostedService.cs
@@ -14,32 +14,76 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 	/// <summary>
 	/// Wraps service run into HostedService
 	/// </summary>
-	internal sealed class OmexHostedService : BackgroundService
+	internal sealed class OmexHostedService : IHostedService
 	{
+		private readonly IHostApplicationLifetime m_lifetime;
 		private readonly IOmexServiceRunner m_runner;
 		private readonly ILogger<OmexHostedService> m_logger;
+		private readonly CancellationTokenSource m_tokenSource;
 
-		public OmexHostedService(IOmexServiceRunner runner, ILogger<OmexHostedService> logger)
+		public OmexHostedService(IOmexServiceRunner runner, IHostApplicationLifetime lifetime, ILogger<OmexHostedService> logger)
 		{
 			m_runner = runner;
+			m_lifetime = lifetime;
 			m_logger = logger;
+			m_tokenSource = new CancellationTokenSource();
 		}
 
-		protected override async Task ExecuteAsync(CancellationToken token)
+		public Task StartAsync(CancellationToken cancellationToken)
+		{
+			m_lifetime.ApplicationStarted.Register(OnServiceStarted);
+			m_lifetime.ApplicationStopping.Register(OnServiceStopping);
+			return Task.CompletedTask;
+		}
+
+		public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+		private void OnServiceStarted() => RunServiceAsync().ContinueWith(OnRunnerCompleted);
+
+		private void OnServiceStopping()
+		{
+			if (m_tokenSource.IsCancellationRequested)
+			{
+				return;
+			}
+
+			m_tokenSource.Cancel();
+		}
+
+		private async Task RunServiceAsync()
 		{
 			try
 			{
-				ConfiguredTaskAwaitable task = m_runner.RunServiceAsync(token).ConfigureAwait(false);
+				await m_runner.RunServiceAsync(m_tokenSource.Token).ConfigureAwait(false);
 
 				m_logger.LogInformation(Tag.Create(), "ServiceFabricHost initialized");
-
-				await task;
 			}
 			catch (Exception e)
 			{
-				m_logger.LogCritical(Tag.Create(), e, "Exception during ServiceFabricHost execution");
+				m_logger.LogCritical(Tag.Create(), e, "Exception during ServiceFabricHost initialization");
+
+				m_lifetime.StopApplication();
+
 				throw;
 			}
+		}
+
+		private Task OnRunnerCompleted(Task task)
+		{
+			if (task.IsFaulted)
+			{
+				m_logger.LogCritical(Tag.Create(), task.Exception, "Service registration stoped due to exeption");
+			}
+			else if (task.IsCanceled)
+			{
+				m_logger.LogInformation(Tag.Create(), "Service registration canceled");
+			}
+			else
+			{
+				m_logger.LogInformation(Tag.Create(), "Service registration stopped");
+			}
+
+			return task;
 		}
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/OmexServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexServiceRegistrator.cs
@@ -34,6 +34,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			ServiceActions = serviceActions;
 		}
 
-		public abstract Task RegisterServiceAsync(CancellationToken cancellationToken);
+		public abstract Task RegisterAsync(CancellationToken cancellationToken);
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/OmexServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexServiceRegistrator.cs
@@ -10,7 +10,7 @@ using Microsoft.Omex.Extensions.Abstractions.Accessors;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
-	internal abstract class OmexServiceRunner<TService, TContext> : IOmexServiceRunner
+	internal abstract class OmexServiceRegistrator<TService, TContext> : IOmexServiceRegistrator
 		where TService : IServiceFabricService<TContext>
 		where TContext : ServiceContext
 	{
@@ -22,7 +22,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 
 		public IEnumerable<IServiceAction<TService>> ServiceActions { get; }
 
-		public OmexServiceRunner(
+		public OmexServiceRegistrator(
 			IHostEnvironment environment,
 			IAccessorSetter<TContext> contextAccessor,
 			IEnumerable<IListenerBuilder<TService>> listenerBuilders,
@@ -34,6 +34,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			ServiceActions = serviceActions;
 		}
 
-		public abstract Task RunServiceAsync(CancellationToken cancellationToken);
+		public abstract Task RegisterServiceAsync(CancellationToken cancellationToken);
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/OmexStatefulServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexStatefulServiceRegistrator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			m_stateAccessor = stateAccessor;
 		}
 
-		public override Task RegisterServiceAsync(CancellationToken cancellationToken) =>
+		public override Task RegisterAsync(CancellationToken cancellationToken) =>
 			ServiceRuntime.RegisterServiceAsync(ApplicationName, ServiceFactory, cancellationToken: cancellationToken);
 
 		private StatefulService ServiceFactory(StatefulServiceContext context)

--- a/src/Extensions/Hosting.Services/Internal/OmexStatefulServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexStatefulServiceRegistrator.cs
@@ -12,9 +12,9 @@ using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
-	internal sealed class OmexStatefulServiceRunner : OmexServiceRunner<OmexStatefulService, StatefulServiceContext>
+	internal sealed class OmexStatefulServiceRegistrator : OmexServiceRegistrator<OmexStatefulService, StatefulServiceContext>
 	{
-		public OmexStatefulServiceRunner(
+		public OmexStatefulServiceRegistrator(
 			IHostEnvironment environment,
 			IAccessorSetter<StatefulServiceContext> contextAccessor,
 			IAccessorSetter<IReliableStateManager> stateAccessor,
@@ -25,7 +25,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			m_stateAccessor = stateAccessor;
 		}
 
-		public override Task RunServiceAsync(CancellationToken cancellationToken) =>
+		public override Task RegisterServiceAsync(CancellationToken cancellationToken) =>
 			ServiceRuntime.RegisterServiceAsync(ApplicationName, ServiceFactory, cancellationToken: cancellationToken);
 
 		private StatefulService ServiceFactory(StatefulServiceContext context)

--- a/src/Extensions/Hosting.Services/Internal/OmexStatelessServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexStatelessServiceRegistrator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			IEnumerable<IServiceAction<OmexStatelessService>> serviceActions)
 				: base(environment, contextAccessor, listenerBuilders, serviceActions) { }
 
-		public override Task RegisterServiceAsync(CancellationToken cancellationToken) =>
+		public override Task RegisterAsync(CancellationToken cancellationToken) =>
 			ServiceRuntime.RegisterServiceAsync(ApplicationName, ServiceFactory, cancellationToken: cancellationToken);
 
 		private StatelessService ServiceFactory(StatelessServiceContext context)

--- a/src/Extensions/Hosting.Services/Internal/OmexStatelessServiceRegistrator.cs
+++ b/src/Extensions/Hosting.Services/Internal/OmexStatelessServiceRegistrator.cs
@@ -11,16 +11,16 @@ using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
-	internal sealed class OmexStatelessServiceRunner : OmexServiceRunner<OmexStatelessService, StatelessServiceContext>
+	internal sealed class OmexStatelessServiceRegistrator : OmexServiceRegistrator<OmexStatelessService, StatelessServiceContext>
 	{
-		public OmexStatelessServiceRunner(
+		public OmexStatelessServiceRegistrator(
 			IHostEnvironment environment,
 			IAccessorSetter<StatelessServiceContext> contextAccessor,
 			IEnumerable<IListenerBuilder<OmexStatelessService>> listenerBuilders,
 			IEnumerable<IServiceAction<OmexStatelessService>> serviceActions)
 				: base(environment, contextAccessor, listenerBuilders, serviceActions) { }
 
-		public override Task RunServiceAsync(CancellationToken cancellationToken) =>
+		public override Task RegisterServiceAsync(CancellationToken cancellationToken) =>
 			ServiceRuntime.RegisterServiceAsync(ApplicationName, ServiceFactory, cancellationToken: cancellationToken);
 
 		private StatelessService ServiceFactory(StatelessServiceContext context)

--- a/src/Extensions/Hosting.Services/OmexStatefulService.cs
+++ b/src/Extensions/Hosting.Services/OmexStatefulService.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 	/// </summary>
 	public sealed class OmexStatefulService : StatefulService, IServiceFabricService<StatefulServiceContext>
 	{
-		private readonly OmexStatefulServiceRunner m_serviceParameters;
+		private readonly OmexStatefulServiceRegistrator m_serviceParameters;
 
 		internal OmexStatefulService(
-			OmexStatefulServiceRunner serviceRunner,
+			OmexStatefulServiceRegistrator serviceRunner,
 			StatefulServiceContext serviceContext)
 				: base(serviceContext) => m_serviceParameters = serviceRunner;
 

--- a/src/Extensions/Hosting.Services/OmexStatelessService.cs
+++ b/src/Extensions/Hosting.Services/OmexStatelessService.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 	/// </summary>
 	public sealed class OmexStatelessService : StatelessService, IServiceFabricService<StatelessServiceContext>
 	{
-		private readonly OmexStatelessServiceRunner m_serviceParameters;
+		private readonly OmexStatelessServiceRegistrator m_serviceParameters;
 
 		internal OmexStatelessService(
-			OmexStatelessServiceRunner serviceRunner,
+			OmexStatelessServiceRegistrator serviceRunner,
 			StatelessServiceContext serviceContext)
 				: base(serviceContext) => m_serviceParameters = serviceRunner;
 

--- a/src/Extensions/Hosting.Services/ServiceFabricHostBuilder.cs
+++ b/src/Extensions/Hosting.Services/ServiceFabricHostBuilder.cs
@@ -12,7 +12,7 @@ using Microsoft.ServiceFabric.Services.Communication.Runtime;
 namespace Microsoft.Omex.Extensions.Hosting.Services
 {
 	/// <summary>
-	/// Wrapper on top of IHostBuilder to propagete proper context type and avoid type registration mistakes
+	/// Wrapper on top of IHostBuilder to propagate proper context type and avoid type registration mistakes
 	/// </summary>
 	public sealed class ServiceFabricHostBuilder<TService, TContext>
 		where TService : IServiceFabricService<TContext>

--- a/src/Extensions/Logging/IExecutionContext.cs
+++ b/src/Extensions/Logging/IExecutionContext.cs
@@ -6,7 +6,7 @@ using System.Net;
 namespace Microsoft.Omex.Extensions.Logging
 {
 	/// <summary>
-	/// Interface with information about the enviroment that executes code
+	/// Interface with information about the environment that executes code
 	/// </summary>
 	public interface IExecutionContext
 	{
@@ -41,7 +41,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		string Cluster { get; }
 
 		/// <summary>
-		/// The ip adress of the deployment cluster to which this machine belongs
+		/// The ip address of the deployment cluster to which this machine belongs
 		/// </summary>
 		IPAddress ClusterIpAddress { get; }
 
@@ -54,7 +54,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// Name of the application
 		/// </summary>
 		/// <remarks>
-		/// Could be the same as service name, but would be diffirent if you running ex. Service Fabric application with multiple services
+		/// Could be the same as service name, but would be different if you running ex. Service Fabric application with multiple services
 		/// </remarks>
 		string ApplicationName { get; }
 

--- a/src/Extensions/Logging/IServiceContext.cs
+++ b/src/Extensions/Logging/IServiceContext.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Omex.Extensions.Logging
 {
 	/// <summary>
-	/// Interface with service context inforormation
+	/// Interface with service context information
 	/// </summary>
 	public interface IServiceContext
 	{

--- a/src/Extensions/TimedScopes/Internal/DiagnosticsObserversInitializer.cs
+++ b/src/Extensions/TimedScopes/Internal/DiagnosticsObserversInitializer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			m_observerLifetime = DiagnosticListener.AllListeners.Subscribe(this);
 			return Task.CompletedTask;
 		}
-		
+
 		public Task StopAsync(CancellationToken cancellationToken)
 		{
 			foreach (IDisposable disposable in m_disposables)

--- a/tests/Extensions/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		[DataRow(typeof(ITimedScopeProvider), null)]
 		[DataRow(typeof(ILogger<HostBuilderExtensionsTests>), null)]
 		[DataRow(typeof(IHostedService), typeof(OmexHostedService))]
-		[DataRow(typeof(IOmexServiceRunner), typeof(OmexStatelessServiceRunner))]
+		[DataRow(typeof(IOmexServiceRegistrator), typeof(OmexStatelessServiceRegistrator))]
 		[DataRow(typeof(IAccessor<StatelessServiceContext>), typeof(Accessor<StatelessServiceContext>))]
 		[DataRow(typeof(IAccessor<ServiceContext>), typeof(Accessor<StatelessServiceContext>))]
 		public void BuildStatelessService_RegisterTypes(Type type, Type? expectedImplementationType)
@@ -80,7 +80,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		[DataRow(typeof(ITimedScopeProvider), null)]
 		[DataRow(typeof(ILogger<HostBuilderExtensionsTests>), null)]
 		[DataRow(typeof(IHostedService), typeof(OmexHostedService))]
-		[DataRow(typeof(IOmexServiceRunner), typeof(OmexStatefulServiceRunner))]
+		[DataRow(typeof(IOmexServiceRegistrator), typeof(OmexStatefulServiceRegistrator))]
 		[DataRow(typeof(IAccessor<StatefulServiceContext>), typeof(Accessor<StatefulServiceContext>))]
 		[DataRow(typeof(IAccessor<ServiceContext>), typeof(Accessor<StatefulServiceContext>))]
 		[DataRow(typeof(IAccessor<IReliableStateManager>), typeof(Accessor<IReliableStateManager>))]

--- a/tests/Extensions/Hosting.Services.UnitTests/MockServiceFabricServices.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/MockServiceFabricServices.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 	{
 		public static OmexStatelessService MockOmexStatelessService { get; } =
 			new OmexStatelessService(
-				new OmexStatelessServiceRunner(
+				new OmexStatelessServiceRegistrator(
 					new Mock<IHostEnvironment>().Object,
 					new Accessor<StatelessServiceContext>(),
 					Enumerable.Empty<IListenerBuilder<OmexStatelessService>>(),
@@ -24,7 +24,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 
 		public static OmexStatefulService MockOmexStatefulService { get; } =
 			new OmexStatefulService(
-				new OmexStatefulServiceRunner(
+				new OmexStatefulServiceRegistrator(
 					new Mock<IHostEnvironment>().Object,
 					new Accessor<StatefulServiceContext>(),
 					new Accessor<IReliableStateManager>(),

--- a/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Omex.Extensions.Hosting.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
@@ -18,44 +18,52 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		public async Task StartAsync_ProperlyCanceled()
 		{
 			MockRunner runnerMock = new MockRunner(t => Task.Delay(int.MaxValue, t));
+			MockLifetime lifetimeMock = new MockLifetime();
 			ILogger<OmexHostedService> loggerMock = new NullLogger<OmexHostedService>();
-			OmexHostedService hostedService = new OmexHostedService(runnerMock, loggerMock);
+			OmexHostedService hostedService = new OmexHostedService(runnerMock, lifetimeMock, loggerMock);
 
 			Assert.IsFalse(runnerMock.IsStarted, "RunServiceAsync should not be called after constructor");
 
-			await hostedService.StartAsync(CancellationToken.None).ConfigureAwait(false);
-			Assert.IsTrue(runnerMock.IsStarted, "RunServiceAsync should be called after StartAsync");
+			await hostedService.StartAsync(CancellationToken.None);
+			Assert.IsFalse(runnerMock.IsStarted, "RunServiceAsync should not be called after StartAsync");
+
+			lifetimeMock.ApplicationStartedSource.Cancel();
+			Assert.IsTrue(runnerMock.IsStarted, "RunServiceAsync should not be called after StartAsync");
 
 			Task task = runnerMock.Task!;
 			Assert.IsFalse(task.IsCanceled, "Task should not be canceled");
 			Assert.IsFalse(runnerMock.Token.IsCancellationRequested, "CancelationToken should not be canceled");
 
-			await hostedService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+			lifetimeMock.ApplicationStoppingSource.Cancel();
 			Assert.IsTrue(runnerMock.Token.IsCancellationRequested, "Task should be canceled");
 			Assert.IsTrue(task.IsCanceled, "CancelationToken should be canceled");
 		}
 
+
 		[TestMethod]
 		public async Task StartAsync_HandlesExceptions()
 		{
-			MockRunner runnerMock = new MockRunner(t => Task.Run(async () =>
-				{
-					await Task.Delay(5).ConfigureAwait(false);
-					throw new ArithmeticException("Totaly valid exeption");
-				}));
+			MockRunner runnerMock = new MockRunner(t => Task.Run(() => throw new Exception("Totaly valid exeption")));
+			MockLifetime lifetimeMock = new MockLifetime();
 			ILogger<OmexHostedService> loggerMock = new NullLogger<OmexHostedService>();
 
-			OmexHostedService hostedService = new OmexHostedService(runnerMock, loggerMock);
+			OmexHostedService hostedService = new OmexHostedService(runnerMock, lifetimeMock, loggerMock);
 			Assert.IsFalse(runnerMock.IsStarted, "RunServiceAsync should not be called after constructor");
 
-			await hostedService.StartAsync(CancellationToken.None).ConfigureAwait(false);
+			await hostedService.StartAsync(CancellationToken.None);
+			Assert.IsFalse(runnerMock.IsStarted, "RunServiceAsync should not be called after StartAsync");
+
+			lifetimeMock.ApplicationStartedSource.Cancel();
 			Assert.IsTrue(runnerMock.IsStarted, "RunServiceAsync should be called after StartAsync");
 			Assert.IsFalse(runnerMock.Token.IsCancellationRequested, "CancelationToken should not be canceled");
 
-			await hostedService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+			await lifetimeMock.CompletionTask;
 			Assert.IsTrue(runnerMock.Task!.IsFaulted, "Task should be faulted");
+
+			lifetimeMock.ApplicationStoppingSource.Cancel();
 			Assert.IsTrue(runnerMock.Token.IsCancellationRequested, "Task should be canceled");
 		}
+
 
 		private class MockRunner : IOmexServiceRunner
 		{
@@ -75,6 +83,35 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 			public MockRunner(Func<CancellationToken, Task> function) => m_function = function;
 
 			private readonly Func<CancellationToken, Task> m_function;
+		}
+
+		private class MockLifetime : IHostApplicationLifetime
+		{
+			public MockLifetime()
+			{
+				ApplicationStartedSource = new CancellationTokenSource();
+				ApplicationStoppingSource = new CancellationTokenSource();
+				ApplicationStoppedSource = new CancellationTokenSource();
+				m_completionSource = new TaskCompletionSource<bool>();
+			}
+
+			public CancellationTokenSource ApplicationStartedSource { get; }
+
+			public CancellationTokenSource ApplicationStoppingSource { get; }
+
+			public CancellationTokenSource ApplicationStoppedSource { get; }
+
+			public Task CompletionTask => m_completionSource.Task;
+
+			public CancellationToken ApplicationStarted => ApplicationStartedSource.Token;
+
+			public CancellationToken ApplicationStopping => ApplicationStoppingSource.Token;
+
+			public CancellationToken ApplicationStopped => ApplicationStoppedSource.Token;
+
+			public void StopApplication() => m_completionSource.SetResult(true);
+
+			private readonly TaskCompletionSource<bool> m_completionSource;
 		}
 	}
 }

--- a/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 
 			public bool IsStarted { get; private set; }
 
-			public Task RegisterServiceAsync(CancellationToken cancellationToken)
+			public Task RegisterAsync(CancellationToken cancellationToken)
 			{
 				IsStarted = true;
 				Token = cancellationToken;

--- a/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/OmexHostedServiceTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		}
 
 
-		private class MockRunner : IOmexServiceRunner
+		private class MockRunner : IOmexServiceRegistrator
 		{
 			public CancellationToken Token { get; private set; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 
 			public bool IsStarted { get; private set; }
 
-			public Task RunServiceAsync(CancellationToken cancellationToken)
+			public Task RegisterServiceAsync(CancellationToken cancellationToken)
 			{
 				IsStarted = true;
 				Token = cancellationToken;


### PR DESCRIPTION
Swicth from `BackgroundService` to `IHostedService` since it's better suitable to control lifetime of the host