### PR TITLE
Rename event sources to allow their usage in existing projects without conflicts

### DIFF
--- a/src/Extensions/Abstractions/EventSources/EventSourcesEventIds.cs
+++ b/src/Extensions/Abstractions/EventSources/EventSourcesEventIds.cs
@@ -79,6 +79,6 @@ namespace Microsoft.Omex.Extensions.Abstractions.EventSources
 		/// <summary>
 		/// Event Id for generic host build failed
 		/// </summary>
-		GenericHostBuildFailed = 17
+		GenericHostFailed = 17
 	}
 }

--- a/src/Extensions/Abstractions/EventSources/EventSourcesEventIds.cs
+++ b/src/Extensions/Abstractions/EventSources/EventSourcesEventIds.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.EventSources
 		/// <summary>
 		/// Event Id for generic host build succeded
 		/// </summary>
-		GenericHostBuildSucceded = 16,
+		GenericHostBuildSucceeded = 16,
 
 		/// <summary>
 		/// Event Id for generic host build failed

--- a/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services/HostBuilderExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			}
 			catch (Exception e)
 			{
-				ServiceInitializationEventSource.Instance.LogHostBuildFailed(e.ToString(), serviceNameForLogging);
+				ServiceInitializationEventSource.Instance.LogHostFailed(e.ToString(), serviceNameForLogging);
 				throw;
 			}
 		}

--- a/src/Extensions/Hosting.Services/Internal/ServiceInitializationEventSource.cs
+++ b/src/Extensions/Hosting.Services/Internal/ServiceInitializationEventSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 	/// <summary>
 	/// Service Fabric event source
 	/// </summary>
-	[EventSource(Name = "Microsoft-OMEX-ServiceInitializationLogs")] //TODO: new event source should be registred GitHub Issue #187
+	[EventSource(Name = "Microsoft-OMEX-HostLogs")] //TODO: new event source should be registred GitHub Issue #187
 	internal sealed class ServiceInitializationEventSource : EventSource
 	{
 		/// <summary>
@@ -19,7 +19,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		public static ServiceInitializationEventSource Instance { get; } = new ServiceInitializationEventSource();
 
 		/// <summary>
-		/// Logs a service type registered ETW event.
+		/// Logs a generic host build success
 		/// </summary>
 		/// <param name="hostProcessId">Host process id</param>
 		/// <param name="serviceType">Service type</param>
@@ -38,19 +38,19 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		}
 
 		/// <summary>
-		/// Logs a service host initialization failed ETW event.
+		/// Logs a generic host failure
 		/// </summary>
 		/// <param name="exception">Exception</param>
 		/// <param name="serviceType">Service type</param>
 		[NonEvent]
-		public void LogHostBuildFailed(string exception, string serviceType)
+		public void LogHostFailed(string exception, string serviceType)
 		{
 			if (!IsEnabled())
 			{
 				return;
 			}
 
-			LogHostBuildFailed(
+			LogHostFailed(
 				exception,
 				serviceType,
 				FormattableString.Invariant($"Service host initialization failed for {serviceType} with exception {exception}"));
@@ -62,8 +62,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		private void LogHostBuildSucceeded(int hostProcessId, string serviceType, string message) =>
 			WriteEvent((int)EventSourcesEventIds.GenericHostBuildSucceded, hostProcessId, serviceType, message);
 
-		[Event((int)EventSourcesEventIds.GenericHostBuildFailed, Level = EventLevel.Error, Message = "{1}", Version = 1)]
-		private void LogHostBuildFailed(string exception, string serviceType, string message) =>
-			WriteEvent((int)EventSourcesEventIds.GenericHostBuildFailed, exception, serviceType, message);
+		[Event((int)EventSourcesEventIds.GenericHostFailed, Level = EventLevel.Error, Message = "{1}", Version = 1)]
+		private void LogHostFailed(string exception, string serviceType, string message) =>
+			WriteEvent((int)EventSourcesEventIds.GenericHostFailed, exception, serviceType, message);
 	}
 }

--- a/src/Extensions/Hosting.Services/Internal/ServiceInitializationEventSource.cs
+++ b/src/Extensions/Hosting.Services/Internal/ServiceInitializationEventSource.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 
 		private ServiceInitializationEventSource() { }
 
-		[Event((int)EventSourcesEventIds.GenericHostBuildSucceded, Level = EventLevel.Informational, Message = "{2}", Version = 1)]
+		[Event((int)EventSourcesEventIds.GenericHostBuildSucceeded, Level = EventLevel.Informational, Message = "{2}", Version = 1)]
 		private void LogHostBuildSucceeded(int hostProcessId, string serviceType, string message) =>
-			WriteEvent((int)EventSourcesEventIds.GenericHostBuildSucceded, hostProcessId, serviceType, message);
+			WriteEvent((int)EventSourcesEventIds.GenericHostBuildSucceeded, hostProcessId, serviceType, message);
 
 		[Event((int)EventSourcesEventIds.GenericHostFailed, Level = EventLevel.Error, Message = "{1}", Version = 1)]
 		private void LogHostFailed(string exception, string serviceType, string message) =>

--- a/src/Extensions/Logging/Internal/EventSource/OmexLogEventSource.cs
+++ b/src/Extensions/Logging/Internal/EventSource/OmexLogEventSource.cs
@@ -7,7 +7,8 @@ using Microsoft.Omex.Extensions.Abstractions.EventSources;
 
 namespace Microsoft.Omex.Extensions.Logging
 {
-	[EventSource(Name = "Microsoft-OMEX-Logs")]
+	// Renamed from Microsoft-OMEX-Logs to avoid conflict with sources in other libraries
+	[EventSource(Name = "Microsoft-OMEX-Logs-Ext")] //TODO: new event source should be registered GitHub Issue #187
 	internal sealed class OmexLogEventSource : EventSource
 	{
 		[Event((int)EventSourcesEventIds.LogError, Level = EventLevel.Error, Message = "{13}", Version = 6)]

--- a/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
+++ b/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
@@ -6,7 +6,8 @@ using Microsoft.Omex.Extensions.Abstractions.EventSources;
 
 namespace Microsoft.Omex.Extensions.TimedScopes
 {
-	[EventSource(Name = "Microsoft-OMEX-TimedScopes")]
+	// Renamed from Microsoft-OMEX-TimedScopes to avoid conflict with sources in other libraries
+	[EventSource(Name = "Microsoft-OMEX-TimedScopes-Ext")] //TODO: new event source should be registered GitHub Issue #187
 	internal sealed class TimedScopeEventSource : EventSource
 	{
 		[Event((int)EventSourcesEventIds.LogTimedScope, Level = EventLevel.Informational, Version = 3)]

--- a/tests/Extensions/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 
 			bool hasErrorEvent = listener.EventsInformation.Any(e =>
 				serviceType == GetPayloadValue<string>(e, ServiceTypePayloadName)
-				&& e.EventId == (int)EventSourcesEventIds.GenericHostBuildFailed);
+				&& e.EventId == (int)EventSourcesEventIds.GenericHostFailed);
 
 			Assert.IsTrue(hasErrorEvent, "BuildStatelessService error should be logged");
 		}
@@ -132,7 +132,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 
 			bool hasErrorEvent = listener.EventsInformation.Any(e =>
 				serviceType == GetPayloadValue<string>(e, ServiceTypePayloadName)
-				&& e.EventId == (int)EventSourcesEventIds.GenericHostBuildFailed);
+				&& e.EventId == (int)EventSourcesEventIds.GenericHostFailed);
 
 			Assert.IsTrue(hasErrorEvent, "BuildStatefulService error should be logged");
 		}


### PR DESCRIPTION
Rename event sources to allow their usage in existing projects without conflicts

There is no way of having to event source object with the same name in a single process, so we need to change names to allow them to co-exist.