### PR TITLE
Improvements in logging classes for better adaptability

### DIFF
--- a/src/Extensions/Logging/ILogEventSender.cs
+++ b/src/Extensions/Logging/ILogEventSender.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -30,6 +31,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <param name="eventId">event Id</param>
 		/// <param name="threadId">Id of the thread</param>
 		/// <param name="message">Log message</param>
-		void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message);
+		/// <param name="exception">The exception, if any, associated with the log.</param>
+		void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception exception);
 	}
 }

--- a/src/Extensions/Logging/ILogEventSender.cs
+++ b/src/Extensions/Logging/ILogEventSender.cs
@@ -32,6 +32,6 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <param name="threadId">Id of the thread</param>
 		/// <param name="message">Log message</param>
 		/// <param name="exception">The exception, if any, associated with the log.</param>
-		void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception exception);
+		void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception? exception);
 	}
 }

--- a/src/Extensions/Logging/Internal/EventSource/OmexLogEventSender.cs
+++ b/src/Extensions/Logging/Internal/EventSource/OmexLogEventSender.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Omex.Extensions.Logging
 			m_options = options;
 		}
 
-		public void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception exception)
+		public void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception? exception)
 		{
 			if (!IsEnabled(level))
 			{

--- a/src/Extensions/Logging/Internal/EventSource/OmexLogEventSender.cs
+++ b/src/Extensions/Logging/Internal/EventSource/OmexLogEventSender.cs
@@ -27,12 +27,15 @@ namespace Microsoft.Omex.Extensions.Logging
 			m_options = options;
 		}
 
-		public void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message)
+		public void LogMessage(Activity? activity, string category, LogLevel level, EventId eventId, int threadId, string message, Exception exception)
 		{
 			if (!IsEnabled(level))
 			{
 				return;
 			}
+
+			// NOTE: Currently, we're not doing anything with the exception as the message when an exception is logged will already contain the exception details.
+			// However, in the future, it's possible we might want to log details, such as exception type or exception message, in separate columns.
 
 			Guid partitionId = m_serviceContext.PartitionId;
 			long replicaId = m_serviceContext.ReplicaOrInstanceId;
@@ -45,7 +48,7 @@ namespace Microsoft.Omex.Extensions.Logging
 			// In case if tag created using Tag.Create (line number and file in description) it's better to display decimal number
 			string tagId = string.IsNullOrWhiteSpace(eventId.Name)
 #pragma warning disable CS0618 // Need to be used for to process reserved tags from GitTagger
-				? TagsExtensions.TagIdAsString(eventId.Id)
+				? eventId.ToTagId()
 #pragma warning restore CS0618
 				: eventId.Id.ToString(CultureInfo.InvariantCulture);
 
@@ -133,7 +136,7 @@ namespace Microsoft.Omex.Extensions.Logging
 			{
 				foreach (LogMessageInformation log in replayableActivity.GetLogEvents())
 				{
-					LogMessage(activity, log.Category, LogLevel.Information, log.EventId, log.ThreadId, log.Message);
+					LogMessage(activity, log.Category, LogLevel.Information, log.EventId, log.ThreadId, log.Message, log.Exception);
 				}
 			}
 		}

--- a/src/Extensions/Logging/Internal/OmexLogger.cs
+++ b/src/Extensions/Logging/Internal/OmexLogger.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Omex.Extensions.Logging
 			int threadId = Thread.CurrentThread.ManagedThreadId;
 			Activity? activity = Activity.Current;
 
-			m_logsEventSender.LogMessage(activity, m_categoryName, logLevel, eventId, threadId, message);
+			m_logsEventSender.LogMessage(activity, m_categoryName, logLevel, eventId, threadId, message, exception);
 
 			if (m_logsEventSender.IsReplayableMessage(logLevel) && activity is ReplayableActivity replayableScope)
 			{
-				replayableScope.AddLogEvent(new LogMessageInformation(m_categoryName, eventId, threadId, message));
+				replayableScope.AddLogEvent(new LogMessageInformation(m_categoryName, eventId, threadId, message, exception));
 			}
 		}
 

--- a/src/Extensions/Logging/Internal/Replayable/LogMessageInformation.cs
+++ b/src/Extensions/Logging/Internal/Replayable/LogMessageInformation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Omex.Extensions.Logging.Replayable
@@ -12,12 +13,15 @@ namespace Microsoft.Omex.Extensions.Logging.Replayable
 		public int ThreadId { get; }
 		public string Message { get; }
 
-		public LogMessageInformation(string category, EventId eventId, int threadId, string message)
+		public Exception Exception { get; }
+
+		public LogMessageInformation(string category, EventId eventId, int threadId, string message, Exception exception)
 		{
 			Category = category;
 			EventId = eventId;
 			ThreadId = threadId;
 			Message = message;
+			Exception = exception;
 		}
 	}
 }

--- a/src/Extensions/Logging/TagsExtensions.cs
+++ b/src/Extensions/Logging/TagsExtensions.cs
@@ -4,16 +4,21 @@
 using System;
 using System.Globalization;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Omex.Extensions.Logging
 {
+	/// <summary>
+	/// Extensions for dealing with legacy Tag IDs.
+	/// </summary>
 	[Obsolete("Added for backward compatability, we are in a process of changing tagging system, please avoid using it if posible", false)]
-	internal static class TagsExtensions
+	public static class TagsExtensions
 	{
 		/// <summary>
-		/// Get the Tag id as a string, please avoid using this method if posible, it's added to support old tag scenario and made internal for unit tests
+		/// Get the Tag id as a string, from an <see cref="EventId"/>.
+		/// Please avoid using this method if posible, it's added to support old tag scenario and made internal for unit tests
 		/// </summary>
-		/// <param name="tagId">tag id</param>
+		/// <param name="eventId">The event ID.</param>
 		/// <returns>the tag as string</returns>
 		/// <remarks>
 		/// In terms of the conversion from integer tag value to equivalent string reprsentation, the following scheme is used:
@@ -25,8 +30,10 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// The conversion is done by treating each group of 6 bits as an index into the symbol space a,b,c,d, ... z, 0, 1, 2, ....9
 		/// eg. 0x000101D0 = 00 000000 000000 010000 000111 010000 2 = aaqhq
 		/// </remarks>
-		internal static string TagIdAsString(int tagId)
+		public static string ToTagId(this EventId eventId)
 		{
+			int tagId = eventId.Id;
+
 			if (tagId <= 0xFFFF)
 			{
 				// Use straight numeric values

--- a/tests/Extensions/Logging.UnitTests/OmexLogEventSenderTests.cs
+++ b/tests/Extensions/Logging.UnitTests/OmexLogEventSenderTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 				new EmptyServiceContext(),
 				Options.Create(new OmexLoggingOptions()));
 
-			logsSender.LogMessage(activity, category, logLevel, tagId, 0, message);
+			logsSender.LogMessage(activity, category, logLevel, tagId, 0, message, new Exception("Not expected to be part of the event"));
 
 			EventWrittenEventArgs eventInfo = listener.EventsInformation.Single(e => e.EventId == (int)eventId);
 

--- a/tests/Extensions/Logging.UnitTests/OmexLoggerProviderTests.cs
+++ b/tests/Extensions/Logging.UnitTests/OmexLoggerProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -28,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 
 			logger.LogError(testMessage);
 
-			mockEventSource.Verify(e => e.LogMessage(It.IsAny<Activity>(), testCategory, LogLevel.Error, It.IsAny<EventId>(), It.IsAny<int>(), testMessage), Times.Once);
+			mockEventSource.Verify(e => e.LogMessage(It.IsAny<Activity>(), testCategory, LogLevel.Error, It.IsAny<EventId>(), It.IsAny<int>(), testMessage, It.IsAny<Exception>()), Times.Once);
 		}
 	}
 }

--- a/tests/Extensions/Logging.UnitTests/OmexLoggerUnitTests.cs
+++ b/tests/Extensions/Logging.UnitTests/OmexLoggerUnitTests.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 	[TestClass]
 	public class OmexLoggerUnitTests
 	{
+		private static readonly Exception s_expectedPropagatedException = new Exception("Test exception");
+
 		[TestMethod]
 		public void LogMessage_PropagatedToEventSource()
 		{
@@ -81,8 +83,8 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 			ReplayableActivity activity = CreateActivity(suffix);
 			activity.Start();
 			(ILogger logger, _) = LogMessage(eventSourceMock, eventId);
-			logger.LogDebug(replayMessage1);
-			logger.LogDebug(replayMessage2);
+			logger.LogDebug(s_expectedPropagatedException, replayMessage1);
+			logger.LogDebug(s_expectedPropagatedException, replayMessage2);
 			activity.Stop();
 
 			eventSourceMock.Verify(m_logExpression, Times.Exactly(3));
@@ -121,7 +123,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 			Mock<IExternalScopeProvider> scopeProvicedMock = new Mock<IExternalScopeProvider>();
 			ILogger logger = new OmexLogger(eventSourceMock.Object, scopeProvicedMock.Object, GetLogCategory(suffix));
 
-			logger.LogError(CreateEventId(eventId, suffix), GetLogMessage(suffix));
+			logger.LogError(CreateEventId(eventId, suffix), s_expectedPropagatedException, GetLogMessage(suffix));
 
 			return (logger, scopeProvicedMock);
 		}
@@ -141,6 +143,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 				It.IsAny<LogLevel>(),
 				It.IsAny<EventId>(),
 				It.IsAny<int>(),
-				It.IsAny<string>());
+				It.IsAny<string>(),
+				s_expectedPropagatedException);
 	}
 }

--- a/tests/Extensions/Logging.UnitTests/TagExtensionsTests.cs
+++ b/tests/Extensions/Logging.UnitTests/TagExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Omex.Extensions.Logging.UnitTests
@@ -19,7 +20,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests
 		public void TagIdAsString_ConvertsProperly(int tagId, string expected)
 		{
 # pragma warning disable 618
-			Assert.AreEqual(expected, TagsExtensions.TagIdAsString(tagId));
+			Assert.AreEqual(expected, new EventId(tagId).ToTagId());
 #pragma warning restore 618
 		}
 	}


### PR DESCRIPTION
In order to support more error details in `ILogEventSender` implementations, a change has been made to pass along the exception, if one was logged.

We've made `TagsExtensions` public, as it needs to be consumed from outside this project. The utils method in there was also converted into an extension method for `EventId` for a more object-oriented approach to consuming the functionality