### PR TITLE
Add both correlationId and activityId into timedscope event

### DIFF
--- a/src/Extensions/TimedScopes/Internal/TimedScopeEventSender.cs
+++ b/src/Extensions/TimedScopes/Internal/TimedScopeEventSender.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 					subType: subTypeAsString,
 					metadata: metaDataAsString,
 					serviceName: serviceNameAsString,
+					logCategory: s_logCategory,
 					result: resultAsString,
 					correlationId: correlationIdAsString,
 					activityId: activityIdAsString,
@@ -88,6 +89,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 					metadata: metaDataAsString,
 					userHash: userHashAsString,
 					serviceName: serviceNameAsString,
+					logCategory: s_logCategory,
 					result: resultAsString,
 					correlationId: correlationIdAsString,
 					activityId: activityIdAsString,
@@ -113,6 +115,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 		private readonly TimedScopeEventSource m_eventSource;
 		private readonly string m_serviceName;
 		private readonly ILogger<TimedScopeEventSender> m_logger;
+		private static readonly string s_logCategory = typeof(TimedScopeEventSource).FullName ?? nameof(TimedScopeEventSource);
 		private const string NullPlaceholder = "null";
 	}
 }

--- a/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
+++ b/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
@@ -17,11 +17,12 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			string metadata,
 			string userHash,
 			string serviceName,
+			string logCategory,
 			string result,
 			string correlationId,
 			string activityId,
 			long durationMs) =>
-			WriteEvent((int)EventSourcesEventIds.LogTimedScope, name, subType, metadata, userHash, serviceName, m_logCategory, result, correlationId, activityId, durationMs);
+			WriteEvent((int)EventSourcesEventIds.LogTimedScope, name, subType, metadata, userHash, serviceName, logCategory, result, correlationId, activityId, durationMs);
 
 		[Event((int)EventSourcesEventIds.LogTimedScopeTestContext, Level = EventLevel.Informational, Version = 3)]
 		public void WriteTimedScopeTestEvent(
@@ -29,17 +30,13 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			string subType,
 			string metadata,
 			string serviceName,
+			string logCategory,
 			string result,
 			string correlationId,
 			string activityId,
 			long durationMs) =>
-			WriteEvent((int)EventSourcesEventIds.LogTimedScopeTestContext, name, subType, metadata, serviceName, m_logCategory, result, correlationId, activityId, durationMs);
+			WriteEvent((int)EventSourcesEventIds.LogTimedScopeTestContext, name, subType, metadata, serviceName, logCategory, result, correlationId, activityId, durationMs);
 
 		public static TimedScopeEventSource Instance { get; } = new TimedScopeEventSource();
-
-		private TimedScopeEventSource() =>
-			m_logCategory = typeof(TimedScopeEventSource).FullName ?? nameof(TimedScopeEventSource);
-
-		private readonly string m_logCategory;
 	}
 }

--- a/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
+++ b/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			string serviceName,
 			string result,
 			string correlationId,
+			string activityId,
 			long durationMs) =>
-			WriteEvent((int)EventSourcesEventIds.LogTimedScope, name, subType, metadata, userHash, serviceName, m_logCategory, result, correlationId, durationMs);
+			WriteEvent((int)EventSourcesEventIds.LogTimedScope, name, subType, metadata, userHash, serviceName, m_logCategory, result, correlationId, activityId, durationMs);
 
 		[Event((int)EventSourcesEventIds.LogTimedScopeTestContext, Level = EventLevel.Informational, Version = 3)]
 		public void WriteTimedScopeTestEvent(
@@ -30,8 +31,9 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			string serviceName,
 			string result,
 			string correlationId,
+			string activityId,
 			long durationMs) =>
-			WriteEvent((int)EventSourcesEventIds.LogTimedScopeTestContext, name, subType, metadata, serviceName, m_logCategory, result, correlationId, durationMs);
+			WriteEvent((int)EventSourcesEventIds.LogTimedScopeTestContext, name, subType, metadata, serviceName, m_logCategory, result, correlationId, activityId, durationMs);
 
 		public static TimedScopeEventSource Instance { get; } = new TimedScopeEventSource();
 

--- a/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
+++ b/src/Extensions/TimedScopes/Internal/TimedScopeEventSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 	[EventSource(Name = "Microsoft-OMEX-TimedScopes-Ext")] //TODO: new event source should be registered GitHub Issue #187
 	internal sealed class TimedScopeEventSource : EventSource
 	{
-		[Event((int)EventSourcesEventIds.LogTimedScope, Level = EventLevel.Informational, Version = 3)]
+		[Event((int)EventSourcesEventIds.LogTimedScope, Level = EventLevel.Informational, Version = 4)]
 		public void WriteTimedScopeEvent(
 			string name,
 			string subType,
@@ -24,7 +24,7 @@ namespace Microsoft.Omex.Extensions.TimedScopes
 			long durationMs) =>
 			WriteEvent((int)EventSourcesEventIds.LogTimedScope, name, subType, metadata, userHash, serviceName, logCategory, result, correlationId, activityId, durationMs);
 
-		[Event((int)EventSourcesEventIds.LogTimedScopeTestContext, Level = EventLevel.Informational, Version = 3)]
+		[Event((int)EventSourcesEventIds.LogTimedScopeTestContext, Level = EventLevel.Informational, Version = 4)]
 		public void WriteTimedScopeTestEvent(
 			string name,
 			string subType,


### PR DESCRIPTION
Add activityId as an additional field to TimedScope events along size with old correlation. Also, fix logCategory passing for TimedScopes.