### PR TITLE
Resolve KestrelServerOptions via DI rather than from KestrelServer

### DIFF
--- a/tests/Extensions/Hosting.Services.Web.UnitTests/ListenerValidator.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/ListenerValidator.cs
@@ -114,7 +114,7 @@ namespace Hosting.Services.Web.UnitTests
 		public IServer ValidateKestrelServerOptionsSet(IWebHost host)
 		{
 			IServer kestrelServer = ResolveType<IServer>(host);
-			KestrelServerOptions kestrelServerOptions = ResolveType<IOptions<KestrelServerOptions>>().Value;
+			KestrelServerOptions kestrelServerOptions = ResolveType<IOptions<KestrelServerOptions>>(host).Value;
 
 			Assert.IsFalse(kestrelServerOptions.AddServerHeader, "AddServerHeader should be false");
 			Assert.IsTrue(kestrelServerOptions.AllowSynchronousIO, "AllowSynchronousIO should be true");

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/ListenerValidator.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/ListenerValidator.cs
@@ -114,7 +114,7 @@ namespace Hosting.Services.Web.UnitTests
 		public IServer ValidateKestrelServerOptionsSet(IWebHost host)
 		{
 			IServer kestrelServer = ResolveType<IServer>(host);
-			KestrelServerOptions kestrelServerOptions = ((KestrelServer)kestrelServer).Options;
+			KestrelServerOptions kestrelServerOptions = ResolveType<IOptions<KestrelServerOptions>>().Value;
 
 			Assert.IsFalse(kestrelServerOptions.AddServerHeader, "AddServerHeader should be false");
 			Assert.IsTrue(kestrelServerOptions.AllowSynchronousIO, "AllowSynchronousIO should be true");


### PR DESCRIPTION
I'm making a change in aspnetcore in 5.0 to change the default type added to Kestrel to a different type. The code to cast IServer to KestrelServer would break. Instead, I believe you can resolve the IOptions<KestrelServerOptions>, which is the recommend way of resolving KestrelServerOptions instead of downcasting IServer.
