### PR TITLE
Switch to use team in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dakanev-msft @davidahs @AndreyTretyak @neilr81 @K-Cully @doguva-msft @aszczepanski @vlad-ion @armhil @muiriswoulfe @sebbe33 @artempushkin @gikoning @vrutz
+* @microsoft/omex


### PR DESCRIPTION
This experimental change should simplify management of the repo and remove the need of adding each person manually to codeowners