### PR TITLE
Detect correlation Id in request header

### DIFF
--- a/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 				return;
 			}
 
-			Guid? oldCorrelation = ExtractCorrelationIdFromQuery(request) ?? ExtractCorrelationIdFromHeader(request);
+			Guid? oldCorrelation = ExtractCorrelationIdFromHeader(request) ?? ExtractCorrelationIdFromQuery(request);
 			if (oldCorrelation.HasValue)
 			{
 				activity.SetObsoleteCorrelationId(oldCorrelation.Value);

--- a/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		{
 			foreach (string name in names)
 			{
-				string? value = ExtractHeader(headers, name);
+				string? value = headers[name];
 				if (!string.IsNullOrWhiteSpace(value))
 				{
 					return value;
@@ -108,11 +108,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 
 			return null;
 		}
-
-		private static string? ExtractHeader(IHeaderDictionary headers, string name) =>
-			headers.TryGetValue(name, out StringValues value) && value.Count > 0
-				? value.FirstOrDefault(s => !string.IsNullOrWhiteSpace(s))
-				: null;
 
 		/// <summary>
 		/// Checks if the context is for a request that contains identifiers indicating that the request originated from an Office client

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/ObsoleteCorrelationHeadersMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/ObsoleteCorrelationHeadersMiddlewareTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
+{
+	[TestClass]
+	public sealed class ObsoleteCorrelationHeadersMiddlewareTests
+	{
+		[Obsolete]
+		[TestInitialize]
+		public void Initialize()
+		{
+			TestActivity = new Activity("ObsoleteCorrelationHeadersMiddlewareTests");
+			TestActivity.Start();
+			TestMiddleware = new ObsoleteCorrelationHeadersMiddleware();
+			TestHttpContext = new DefaultHttpContext();
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			TestActivity.Stop();
+		}
+
+		[Obsolete]
+		[DataTestMethod]
+		[DataRow("MS-CorrelationId")]
+		[DataRow("ms-correlationid")]
+		[DataRow("corr")]
+		[DataRow("HTTP_X_CORRELATIONID")]
+		public async Task SetsObsoleteCorrelationIdFromHeaderToActivity(string correlationName)
+		{
+			// Arrange
+			Guid obsoleteCorrelation = new Guid();
+			TestHttpContext.Request.Headers.Add(correlationName, obsoleteCorrelation.ToString());
+
+			// Act
+			await TestMiddleware.InvokeAsync(TestHttpContext, DummyDelegate);
+
+			// Assert
+			Assert.AreEqual(obsoleteCorrelation.ToString(), TestActivity.GetBaggageItem("ObsoleteCorrelationId"));
+		}
+
+		[Obsolete]
+		[DataTestMethod]
+		[DataRow("MS-CorrelationId")]
+		[DataRow("ms-correlationid")]
+		[DataRow("corr")]
+		[DataRow("HTTP_X_CORRELATIONID")]
+		public async Task SetsObsoleteCorrelationIdFromHeaderToHeader(string correlationName)
+		{
+			// Arrange
+			Guid obsoleteCorrelation = new Guid();
+
+			// Mock the HttpResponse feature to test response header rewrite
+			Mock<IHttpResponseFeature> feature = new Mock<IHttpResponseFeature>();
+			HeaderDictionary dict = new HeaderDictionary();
+			feature.Setup(x => x.Headers).Returns(dict);
+			feature
+				.Setup(x => x.OnStarting(It.IsAny<Func<object, Task>>(), It.IsAny<HttpResponse>()))
+				.Callback<Func<object, Task>, object>((callback, _) => callback(TestHttpContext.Response));
+			TestHttpContext.Features.Set(feature.Object);
+
+			TestHttpContext.Request.Headers.Add(correlationName, obsoleteCorrelation.ToString());
+
+			// Act
+			await TestMiddleware.InvokeAsync(TestHttpContext, DummyDelegate);
+
+			// Assert
+			TestHttpContext.Response.Headers.TryGetValue("X-CorrelationId", out StringValues value);
+			Assert.AreEqual(obsoleteCorrelation.ToString(), value.ToString());
+		}
+
+		private Activity TestActivity { get; set; } = new Activity("ObsoleteCorrelationHeadersMiddlewareTests");
+
+		[Obsolete]
+		private IMiddleware TestMiddleware { get; set; } = new ObsoleteCorrelationHeadersMiddleware();
+
+		private RequestDelegate DummyDelegate { get; set; } = (HttpContext hc) => Task.CompletedTask;
+
+		private HttpContext TestHttpContext { get; set; } = new DefaultHttpContext();
+	}
+}

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/ObsoleteCorrelationHeadersMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/ObsoleteCorrelationHeadersMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 		public async Task SetsObsoleteCorrelationIdFromHeaderToActivity(string correlationName)
 		{
 			// Arrange
-			Guid obsoleteCorrelation = new Guid();
+			Guid obsoleteCorrelation = Guid.NewGuid();
 			TestHttpContext.Request.Headers.Add(correlationName, obsoleteCorrelation.ToString());
 
 			// Act
@@ -58,7 +58,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 		public async Task SetsObsoleteCorrelationIdFromHeaderToHeader(string correlationName)
 		{
 			// Arrange
-			Guid obsoleteCorrelation = new Guid();
+			Guid obsoleteCorrelation = Guid.NewGuid();
 
 			// Mock the HttpResponse feature to test response header rewrite
 			Mock<IHttpResponseFeature> feature = new Mock<IHttpResponseFeature>();


### PR DESCRIPTION
Allow the obsolete correlation middleware to also detect correlation Ids set in the request header