### PR TITLE
Attempt remove net472 as a targets for packages

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -5,25 +5,24 @@
     <Microsoft_AspNetCore_Http_Abstractions_Version>2.2.0</Microsoft_AspNetCore_Http_Abstractions_Version>
     <Microsoft_AspNetCore_Http_Version>2.2.2</Microsoft_AspNetCore_Http_Version>
     <Microsoft_Azure_DocumentDB_Version>2.11.0</Microsoft_Azure_DocumentDB_Version>
-    <Microsoft_Net_Test_Sdk_Version>16.6.1</Microsoft_Net_Test_Sdk_Version>
+    <Microsoft_Net_Test_Sdk_Version>16.7.1</Microsoft_Net_Test_Sdk_Version>
     <Microsoft_SourceLink_GitHub_Version>1.0.0</Microsoft_SourceLink_GitHub_Version>
     <Microsoft_SourceLink_AzureRepos_Git_Version>1.0.0</Microsoft_SourceLink_AzureRepos_Git_Version>
-    <MSTest_TestAdapter_Version>2.1.1</MSTest_TestAdapter_Version>
-    <MSTest_TestFramework_Version>2.1.1</MSTest_TestFramework_Version>
+    <MSTest_TestAdapter_Version>2.1.2</MSTest_TestAdapter_Version>
+    <MSTest_TestFramework_Version>2.1.2</MSTest_TestFramework_Version>
     <System_Configuration_ConfigurationManager_Version>4.7.0</System_Configuration_ConfigurationManager_Version>
     <System_ServiceModel_Primitives_Version>4.7.0</System_ServiceModel_Primitives_Version>
     <System_Threading_Tasks_Version>4.3.0</System_Threading_Tasks_Version>
-    <Xunit_Runner_VisualStudio_Version>2.4.2</Xunit_Runner_VisualStudio_Version>
+    <Xunit_Runner_VisualStudio_Version>2.4.3</Xunit_Runner_VisualStudio_Version>
+    <Moq_Version>4.14.5</Moq_Version>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions Core. AutoUpdate">
     <Bond_Core_CSharp_Version_Core>9.0.0</Bond_Core_CSharp_Version_Core>
-    <Moq_Version_Core>4.14.3</Moq_Version_Core>
     <System_Collections_Immutable_Version_Core>1.7.1</System_Collections_Immutable_Version_Core>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions. Pinned">
     <Bond_Core_CSharp_Version>6.0.0</Bond_Core_CSharp_Version>
     <Microsoft_Azure_DocumentDb_Version>2.5.1</Microsoft_Azure_DocumentDb_Version>
-    <Moq_Version>4.5.22</Moq_Version>
     <System_Collections_Immutable_Version>1.2.0</System_Collections_Immutable_Version>
     <Xunit_Assert_Version>2.4.1</Xunit_Assert_Version>
     <Xunit_Core_Version>2.4.1</Xunit_Core_Version>

--- a/Dependencies.props
+++ b/Dependencies.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Package Versions. AutoUpdate">
+    <Moq_Version>4.14.5</Moq_Version>
     <Microsoft_AspNetCore_Hosting_Abstractions_Version>2.2.0</Microsoft_AspNetCore_Hosting_Abstractions_Version>
     <Microsoft_AspNetCore_Http_Abstractions_Version>2.2.0</Microsoft_AspNetCore_Http_Abstractions_Version>
     <Microsoft_AspNetCore_Http_Version>2.2.2</Microsoft_AspNetCore_Http_Version>
@@ -14,7 +15,6 @@
     <System_ServiceModel_Primitives_Version>4.7.0</System_ServiceModel_Primitives_Version>
     <System_Threading_Tasks_Version>4.3.0</System_Threading_Tasks_Version>
     <Xunit_Runner_VisualStudio_Version>2.4.3</Xunit_Runner_VisualStudio_Version>
-    <Moq_Version>4.14.5</Moq_Version>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions Core. AutoUpdate">
     <Bond_Core_CSharp_Version_Core>9.0.0</Bond_Core_CSharp_Version_Core>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,7 @@
   <PropertyGroup Label="Target Platforms" >
     <NetCoreVersions>netcoreapp3.1</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>
-    <NetFrameworkVersions>net472</NetFrameworkVersions> <!-- Framework version that should be targeted alongside with .net standard -->
-    <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions);$(NetFrameworkVersions)</LibraryTargetFrameworks>
-    <LibraryTargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
 </PropertyGroup>
   <PropertyGroup Label="Project Settings" >

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,12 @@
     <NetStandardVersions>netstandard2.0</NetStandardVersions>
     <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
-</PropertyGroup>
+  </PropertyGroup>
+  <PropertyGroup Label="UnitTest Targets">
+    <NetFameworkVersion>net472</NetFameworkVersion>
+    <UnitTestTargetValues>$(NetCoreVersions);$(NetFameworkVersion)</UnitTestTargetValues>
+    <UnitTestTargetValues Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions)</UnitTestTargetValues>
+  </PropertyGroup>
   <PropertyGroup Label="Project Settings" >
     <Platforms>AnyCPU</Platforms>
     <TargetPlatform>AnyCPU</TargetPlatform>
@@ -19,7 +24,8 @@
   <PropertyGroup Label="Condition Variables" >
     <IsNetStandard>$(NetStandardVersions.Contains('$(TargetFramework)'))</IsNetStandard>
     <IsNetCore>$(NetCoreVersions.Contains('$(TargetFramework)'))</IsNetCore>
-    <IsNetFramework>$(NetFrameworkVersions.Contains('$(TargetFramework)'))</IsNetFramework>
+    <IsNetFramework>false</IsNetFramework>
+    <IsNetFramework Condition="!$(IsNetStandard) And !$(IsNetCore)">true</IsNetFramework>
   </PropertyGroup>
   <PropertyGroup Label="Signing" >
     <SignAssembly>true</SignAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
-    <NetFameworkVersion>net472</NetFameworkVersion>
-    <UnitTestTargetValues>$(NetCoreVersions);$(NetFameworkVersion)</UnitTestTargetValues>
-    <UnitTestTargetValues Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions)</UnitTestTargetValues>
+    <NetFrameworkVersion>net472</NetFrameworkVersion>
+    <UnitTestTargetFrameworks>$(NetCoreVersions);$(NetFrameworkVersion)</UnitTestTargetFrameworks>
+    <UnitTestTargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions)</UnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="Project Settings" >
     <Platforms>AnyCPU</Platforms>

--- a/src/Extensions/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Extensions/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="BuildTransitive\*" Pack="true" PackagePath="buildTransitive" />

--- a/src/Extensions/Abstractions/NotNullWhenAttribute.cs
+++ b/src/Extensions/Abstractions/NotNullWhenAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-#if NETSTANDARD2_0 // This marker attribute only available starting from netstandard 2.1, so we need a replacement to build for full framework
+#if NETSTANDARD2_0 || NETFRAMEWORK // This marker attribute only available starting from netstandard 2.1, so we need a replacement to build for full framework
 namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>

--- a/src/Extensions/Abstractions/Validation.cs
+++ b/src/Extensions/Abstractions/Validation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Omex.Extensions.Abstractions
 		{
 			if (!string.IsNullOrWhiteSpace(value))
 			{
-				return value!; // `!` required because in net472 IsNullOrWhiteSpace does not have proper attributes
+				return value!; // `!` required because in netstandard2.0 IsNullOrWhiteSpace does not have proper attributes
 			}
 
 			_ = value ?? throw new ArgumentNullException(name);

--- a/src/Extensions/Compatibility.UlsLoggerAdapter/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.csproj
+++ b/src/Extensions/Compatibility.UlsLoggerAdapter/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System\Microsoft.Omex.System.csproj" />

--- a/src/Extensions/Compatibility.UlsLoggerAdapter/UlsLogAddapter.cs
+++ b/src/Extensions/Compatibility.UlsLoggerAdapter/UlsLogAddapter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter
 			return Task.CompletedTask;
 		}
 
-		private void LogEvent(object sender, LogEventArgs e)
+		private void LogEvent(object? sender, LogEventArgs e)
 		{
 			m_loggersDictionary.GetOrAdd(e.CategoryId.Name, m_loggerFactory.CreateLogger).Log(
 				Convert(e.Level),

--- a/src/Extensions/Compatibility/Microsoft.Omex.Extensions.Compatibility.csproj
+++ b/src/Extensions/Compatibility/Microsoft.Omex.Extensions.Compatibility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(Microsoft_Extensions_Hosting_Abstractions_Version)" />

--- a/src/Extensions/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Extensions/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/Directory.Build.props
+++ b/src/Extensions/Directory.Build.props
@@ -1,9 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(_DirectoryBuildPropsFile)', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <NetStandardVersion>netstandard2.0</NetStandardVersion>
-    <NetCoreVersion>netcoreapp3.1</NetCoreVersion>
-    <TargetFrameworksValue>$(NetFameworkVersion);$(NetStandardVersion)</TargetFrameworksValue>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Extensions/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
+++ b/src/Extensions/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
+++ b/src/Extensions/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
+++ b/src/Extensions/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/Hosting/Certificates/CertificateReader.cs
+++ b/src/Extensions/Hosting/Certificates/CertificateReader.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Certificates
 
 		private CertificateInformation[] LoadCertificates(StoreName storeName, bool refreshCache)
 		{
-			if (refreshCache || !m_certificatesCache.TryGetValue(storeName, out CertificateInformation[] certificates))
+			if (refreshCache || !m_certificatesCache.TryGetValue(storeName, out CertificateInformation[]? certificates))
 			{
 				m_logger.LogInformation(Tag.Create(), "Updating certificates cache for store '{0}'.", storeName);
 

--- a/src/Extensions/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
+++ b/src/Extensions/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(Microsoft_Extensions_Hosting_Abstractions_Version)" />

--- a/src/Extensions/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Extensions/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(Microsoft_Extensions_Logging_Version)" />

--- a/src/Extensions/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
+++ b/src/Extensions/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/TimedScopes/Microsoft.Omex.Extensions.TimedScopes.csproj
+++ b/src/Extensions/TimedScopes/Microsoft.Omex.Extensions.TimedScopes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(Microsoft_Extensions_Hosting_Abstractions_Version)" />

--- a/src/Gating.UnitTests.Shared/Microsoft.Omex.Gating.UnitTests.Shared.csproj
+++ b/src/Gating.UnitTests.Shared/Microsoft.Omex.Gating.UnitTests.Shared.csproj
@@ -21,10 +21,4 @@
     <ProjectReference Include="..\System.UnitTests.Shared\Microsoft.Omex.System.UnitTests.Shared.csproj" />
     <ProjectReference Include="..\System\Microsoft.Omex.System.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="!$(IsNetStandard)">
-    <PackageReference Include="System.Collections.Immutable" Version="$(System_Collections_Immutable_Version)" />
-  </ItemGroup>
-  <ItemGroup Condition="$(IsNetStandard)">
-    <PackageReference Include="System.Collections.Immutable" Version="$(System_Collections_Immutable_Version_Core)" />
-  </ItemGroup>
 </Project>

--- a/tests/Extensions/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
+++ b/tests/Extensions/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Extensions\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/tests/Extensions/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
+++ b/tests/Extensions/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Extensions\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Extensions/Compatibility.UnitTests/Microsoft.Omex.Extensions.Compatibility.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UnitTests/Microsoft.Omex.Extensions.Compatibility.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Compatibility.UnitTests/Microsoft.Omex.Extensions.Compatibility.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UnitTests/Microsoft.Omex.Extensions.Compatibility.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Directory.Build.props
+++ b/tests/Extensions/Directory.Build.props
@@ -1,19 +1,14 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(_DirectoryBuildPropsFile)', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <NetFameworkVersion>net472</NetFameworkVersion>
-    <NetCoreVersion>netcoreapp3.1</NetCoreVersion>
-    <TargetFrameworksValue>$(NetFameworkVersion);$(NetCoreVersion)</TargetFrameworksValue>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_Net_Test_Sdk_Version)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTest_TestAdapter_Version)" PrivateAssets="All" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTest_TestFramework_Version)" />
-    <PackageReference Include="Moq" Version="$(Moq_Version_Core)" />
+    <PackageReference Include="Moq" Version="$(Moq_Version)" />
     <!-- exclude xunit packages used in other test projest -->
     <PackageReference Remove="xunit.runner.visualstudio" />
     <PackageReference Remove="xunit.assert" />

--- a/tests/Extensions/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
+++ b/tests/Extensions/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
+++ b/tests/Extensions/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
+++ b/tests/Extensions/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
+++ b/tests/Extensions/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
+++ b/tests/Extensions/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Extensions/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
+++ b/tests/Extensions/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Extensions/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
+++ b/tests/Extensions/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(Microsoft_Extensions_DependencyInjection_Version)" />

--- a/tests/Extensions/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
+++ b/tests/Extensions/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(Microsoft_Extensions_DependencyInjection_Version)" />

--- a/tests/Extensions/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
+++ b/tests/Extensions/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
+++ b/tests/Extensions/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Extensions/TimedScopes.UnitTests/Microsoft.Omex.Extensions.TimedScopes.UnitTests.csproj
+++ b/tests/Extensions/TimedScopes.UnitTests/Microsoft.Omex.Extensions.TimedScopes.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Extensions/TimedScopes.UnitTests/Microsoft.Omex.Extensions.TimedScopes.UnitTests.csproj
+++ b/tests/Extensions/TimedScopes.UnitTests/Microsoft.Omex.Extensions.TimedScopes.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksValue)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />

--- a/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
+++ b/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="17.0">
   <PropertyGroup>
-    <TargetFrameworks>$(ExecutableTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
     <Description>Contains Omex Gating Unit Tests</Description>
     <RootNamespace>Microsoft.Omex.Gating.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Omex.Gating.UnitTests</AssemblyName>
@@ -15,10 +15,8 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(System_Collections_Immutable_Version)" />
   </ItemGroup>
   <ItemGroup Condition="$(IsNetCore)">
-    <PackageReference Include="System.Collections.Immutable" Version="$(System_Collections_Immutable_Version_Core)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(Microsoft_AspNetCore_Http_Abstractions_Version)" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
+++ b/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="17.0">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <Description>Contains Omex Gating Unit Tests</Description>
     <RootNamespace>Microsoft.Omex.Gating.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Omex.Gating.UnitTests</AssemblyName>

--- a/tests/System.UnitTests/Microsoft.Omex.System.UnitTests.csproj
+++ b/tests/System.UnitTests/Microsoft.Omex.System.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="!$(IsNetCore)">
     <Reference Include="System.Runtime" />

--- a/tests/System.UnitTests/Microsoft.Omex.System.UnitTests.csproj
+++ b/tests/System.UnitTests/Microsoft.Omex.System.UnitTests.csproj
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(ExecutableTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetValues)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="!$(IsNetCore)">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
-    <PackageReference Include="Moq" Version="$(Moq_Version)" />
   </ItemGroup>
-  <ItemGroup Condition="$(IsNetCore)">
-    <PackageReference Include="Moq" Version="$(Moq_Version_Core)" />
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="$(Moq_Version)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.UnitTests.Shared\Microsoft.Omex.System.UnitTests.Shared.csproj" />


### PR DESCRIPTION
Theoretically, we don't need net472 as a target anymore since it could use netstandard2.0 instead, we'll see how it will work :)