### PR TITLE
Fixed a bug in HttpClient handler configuration

### DIFF
--- a/src/Extensions/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -19,16 +19,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// </summary>
 		public static IHealthChecksBuilder AddServiceFabricHealthChecks(this IServiceCollection serviceCollection)
 		{
-			HttpClientHandler clientHandler = new HttpClientHandler
-			{
-				AllowAutoRedirect = false,
-				Credentials = CredentialCache.DefaultCredentials,
-				ServerCertificateCustomValidationCallback = (sender, x509Certificate, chain, errors) => true
-			};
-
 			serviceCollection
 				.AddHttpClient(HttpEndpointHealthCheck.HttpClientLogicalName)
-				.ConfigurePrimaryHttpMessageHandler(() => clientHandler);
+				.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+				{
+					AllowAutoRedirect = false,
+					Credentials = CredentialCache.DefaultCredentials,
+					ServerCertificateCustomValidationCallback = (sender, x509Certificate, chain, errors) => true
+				});
 
 			return serviceCollection
 				.AddHealthCheckPublisher<ServiceFabricHealthCheckPublisher>()


### PR DESCRIPTION
ConfigurePrimaryHttpMessageHandler must return a new instance of HttpClientHandler every time, otherwise you hit an ObjectDisposed exception. See https://github.com/dotnet/runtime/issues/27610 for an example of the issue.