### PR TITLE
Throw proper exception if service not found

### DIFF
--- a/src/Extensions/Hosting.Services.Remoting/HostBuilderExtensions.cs
+++ b/src/Extensions/Hosting.Services.Remoting/HostBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
 				where TService : IService =>
-					builder.AddRemotingListener(name, (provider, _) => provider.GetService<TService>(), settings);
+					builder.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
 
 		/// <summary>
 		/// Adds remote listener to stateful service


### PR DESCRIPTION
using `GetRequiredService` will provide proper exception with an explanation that the service should be registered or why it's not resolved

UT would be added separately https://github.com/microsoft/Omex/issues/260