### PR TITLE
Fix header update for remoting calls

### DIFF
--- a/src/Extensions/Services.Remoting/OmexRemotingHeadersExtensions.cs
+++ b/src/Extensions/Services.Remoting/OmexRemotingHeadersExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 			}
 
 			IServiceRemotingRequestMessageHeader header = requestMessage.GetHeader();
-			if (header.TryGetHeaderValue(TraceParentHeaderName, out byte[] _)) // header updagte not supported
+			if (header.TryGetHeaderValue(TraceParentHeaderName, out byte[] _)) // header update not supported
 			{
 				header.AddHeader(TraceParentHeaderName, s_encoding.GetBytes(activity.Id));
 				header.AddHeader(TraceStateHeaderName, SerializeBaggage(activity.Baggage.ToArray()));


### PR DESCRIPTION
Calling Add on remoting header when it already exists causes exception, so we need to check before adding. 
Also, it would be nice to have some more UT coverage of this area.