### PR TITLE
Fixed some issues in SF health check publisher.

### DIFF
--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 	{
 		internal const string HealthReportSourceId = nameof(ServiceFabricHealthCheckPublisher);
 
-		internal const string HealthReportSummaryProperty = "HealthChecksSummary";
+		internal const string HealthReportSummaryProperty = "HealthReportSummary";
 
 		private readonly IAccessor<IServicePartition> m_partitionAccessor;
 

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
 	internal class ServiceFabricHealthCheckPublisher : IHealthCheckPublisher
 	{
-		private const string SfHealthInformationSourceId = nameof(ServiceFabricHealthCheckPublisher);
+		internal const string HealthReportSourceId = nameof(ServiceFabricHealthCheckPublisher);
+
+		internal const string HealthReportSummaryProperty = "HealthChecksSummary";
 
 		private readonly IAccessor<IServicePartition> m_partitionAccessor;
 
@@ -82,7 +84,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				descriptionBuilder.Append("Exception: ").Append(reportEntry.Exception).AppendLine();
 			}
 
-			return new SfHealthInformation(SfHealthInformationSourceId, healthCheckName, ToSfHealthState(reportEntry.Status))
+			return new SfHealthInformation(HealthReportSourceId, healthCheckName, ToSfHealthState(reportEntry.Status))
 			{
 				Description = descriptionBuilder.ToString(),
 			};
@@ -120,7 +122,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				.AppendFormat("Total duration: {0}.", report.TotalDuration)
 				.AppendLine();
 
-			return new SfHealthInformation(SfHealthInformationSourceId, "HealthChecksSummary", ToSfHealthState(report.Status))
+			return new SfHealthInformation(HealthReportSourceId, HealthReportSummaryProperty, ToSfHealthState(report.Status))
 			{
 				Description = descriptionBuilder.ToString(),
 			};

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
-using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Omex.Extensions.Abstractions.Accessors;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using SfHealthInformation = System.Fabric.Health.HealthInformation;
 using SfHealthState = System.Fabric.Health.HealthState;
 
@@ -17,96 +20,244 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 	[TestClass]
 	public class ServiceFabricHealthCheckPublisherTests
 	{
+		private ILogger<ServiceFabricHealthCheckPublisher> NullLogger { get; } = new NullLogger<ServiceFabricHealthCheckPublisher>();
+
 		[TestMethod]
-		public void PublishAsync_ReportsToServiceFabric()
+		public async Task PublishAsync_WhenPartitionIsNotAvailable_ReturnsGracefully()
 		{
-			string healthyCheckName = "HealthyCheck";
-			string degradedCheckName = "DegradedCheck";
-			string unhealthyCheckName = "UnhealthyCheck";
+			// Arrange.
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(null);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
 
-			MockServicePartition partition = new MockServicePartition();
+			// Act.
+			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
-			HealthReport report = new HealthReport(new Dictionary<string, HealthReportEntry>()
-			{
-				{ healthyCheckName, CreateEntry(HealthStatus.Healthy, "testDescription1") },
-				{ degradedCheckName, CreateEntry(HealthStatus.Degraded, "testDescription2", new ArithmeticException()) },
-				{ unhealthyCheckName, CreateEntry(HealthStatus.Unhealthy, "testDescription3", new ArgumentOutOfRangeException() ) }
-			}, default);
-
-			Accessor<IServicePartition> accessor = new Accessor<IServicePartition>();
-			IHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(accessor, new NullLogger<ServiceFabricHealthCheckPublisher>());
-
-			publisher.PublishAsync(report, default); // publish not failing if IServicePartition not available
-
-			(accessor as IAccessorSetter<IServicePartition>).SetValue(partition);
-
-			publisher.PublishAsync(report, default);
-
-			AssertHealtItem(partition, healthyCheckName, report);
-			AssertHealtItem(partition, degradedCheckName, report);
-			AssertHealtItem(partition, degradedCheckName, report);
+			// Assert.
+			// If we are here, PublishAsync didn't explode.
 		}
 
-		private void AssertHealtItem(MockServicePartition partition, string name, HealthReport report)
+		[TestMethod]
+		public async Task PublishAsync_ForStatefulServicePartition_ReportsReplicaHealth()
 		{
-			HealthReportEntry entry = report.Entries[name];
-			SfHealthInformation? info = partition.HealthInformation.SingleOrDefault(h => string.Equals(h.Property, name, StringComparison.OrdinalIgnoreCase));
-			Assert.IsNotNull(info, name);
+			// Arrange.
+			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
 
-			Assert.AreEqual(GetMachingState(entry.Status), info.HealthState, nameof(HealthReportEntry.Status));
+			// Act.
+			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
-			if (entry.Status == HealthStatus.Healthy)
-			{
-				Assert.AreEqual(info.Description, entry.Description, nameof(HealthReportEntry.Description));
-			}
-			else
-			{
-				StringAssert.Contains(info.Description, entry.Description, nameof(HealthReportEntry.Description));
-				StringAssert.Contains(info.Description, entry.Exception.ToString(), nameof(HealthReportEntry.Exception));
-				StringAssert.Contains(info.Description, entry.Duration.ToString(), nameof(HealthReportEntry.Duration));
-
-				int index = 0;
-				foreach (string tag in entry.Tags)
-				{
-					StringAssert.Contains(info.Description, tag, nameof(HealthReportEntry.Tags) + index);
-					index++;
-				}
-			}
+			// Assert.
+			mockPartition.Verify(partition => partition.ReportReplicaHealth(It.IsAny<SfHealthInformation>()));
 		}
 
-		private SfHealthState GetMachingState(HealthStatus state) =>
-			state switch
-			{
-				HealthStatus.Healthy => SfHealthState.Ok,
-				HealthStatus.Degraded => SfHealthState.Warning,
-				HealthStatus.Unhealthy => SfHealthState.Error,
-				_ => SfHealthState.Invalid,
-			};
-
-		private HealthReportEntry CreateEntry(HealthStatus status, string description, Exception? exception = null) =>
-			new HealthReportEntry(
-				status,
-				description,
-				TimeSpan.FromMinutes(1),
-				exception,
-				new Dictionary<string, object>());
-
-		private class MockServicePartition : IServicePartition
+		[TestMethod]
+		public async Task PublishAsync_ForStatelessServicePartition_ReportsInstanceHealth()
 		{
-			public List<SfHealthInformation> HealthInformation { get; } = new List<SfHealthInformation>();
+			// Arrange.
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
 
-			public ServicePartitionInformation PartitionInfo => throw new NotImplementedException();
+			// Act.
+			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
-			public void ReportFault(FaultType faultType) => throw new NotImplementedException();
+			// Assert.
+			mockPartition.Verify(partition => partition.ReportInstanceHealth(It.IsAny<SfHealthInformation>()));
+		}
 
-			public void ReportLoad(IEnumerable<LoadMetric> metrics) => throw new NotImplementedException();
+		[TestMethod]
+		public async Task PublishAsync_ForUnknownPartitionType_ThrowsArgumentException()
+		{
+			// Arrange.
+			Mock<IServicePartition> mockPartition = new Mock<IServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
 
-			public void ReportMoveCost(MoveCost moveCost) => throw new NotImplementedException();
+			// Act.
+			async Task act() => await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
-			public void ReportPartitionHealth(SfHealthInformation healthInfo) => HealthInformation.Add(healthInfo);
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			string partitionTypeName = mockPartition.Object.GetType().ToString();
+			StringAssert.Contains(actualException.Message, partitionTypeName);
+		}
 
-			public void ReportPartitionHealth(SfHealthInformation healthInfo, System.Fabric.Health.HealthReportSendOptions sendOptions) =>
-				ReportPartitionHealth(healthInfo);
+		[DataTestMethod]
+		[DataRow("TestHealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
+		[DataRow("TestDegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
+		[DataRow("TestUnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
+		public async Task PublishAsync_ForHealthCheckWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
+		{
+			// Arrange.
+			SfHealthInformation? reportedSfHealthInformation = null;
+
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.Is<SfHealthInformation>(info => info.Property == healthCheckName)))
+				.Callback<SfHealthInformation>(info => reportedSfHealthInformation = info);
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, healthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			await publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			Assert.AreEqual(expectedSfHealthState, reportedSfHealthInformation?.HealthState);
+		}
+
+		[DataTestMethod]
+		[DataRow("NegativeInvalidStatusCheck", -1)]
+		[DataRow("PositiveInvalidStatusCheck", 3)]
+		public async Task PublishAsync_ForHealthCheckWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
+		{
+			// Arrange.
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, invalidHealthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			async Task act() => await publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
+		}
+
+		[DataTestMethod]
+		[DataRow("TestHealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
+		[DataRow("TestDegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
+		[DataRow("TestUnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
+		public async Task PublishAsync_ForReportWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
+		{
+			// Arrange.
+			SfHealthInformation? reportedSfHealthInformation = null;
+
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.Is<SfHealthInformation>(info => info.Property == ServiceFabricHealthCheckPublisher.HealthReportSummaryProperty)))
+				.Callback<SfHealthInformation>(info => reportedSfHealthInformation = info);
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			// Currently report status is calculated as the worst of all healthchecks. In .NET 5 it will be possible to set it independently.
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, healthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			await publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			Assert.AreEqual(expectedSfHealthState, reportedSfHealthInformation?.HealthState);
+		}
+
+		[DataTestMethod]
+		[DataRow("NegativeInvalidStatusCheck", -1)]
+		[DataRow("PositiveInvalidStatusCheck", 3)]
+		public async Task PublishAsync_ForReportWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
+		{
+			// Arrange.
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			// Currently report status is calculated as the worst of all entries. In .NET 5 it will be possible to set it independently.
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, invalidHealthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			async Task act() => await publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_WhenCancellationTokenIsCancelled_ThrowsOperationCanceledException()
+		{
+			// Arrange.
+			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			CancellationTokenSource tokenSource = new CancellationTokenSource();
+			tokenSource.Cancel();
+
+			// Act.
+			async Task act() => await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, tokenSource.Token);
+
+			// Assert.
+			OperationCanceledException actualException = await Assert.ThrowsExceptionAsync<OperationCanceledException>(act);
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_WhenStatelessPartitionIsClosed_ReturnsGracefully()
+		{
+			// Arrange.
+			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
+			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.IsAny<SfHealthInformation>()))
+				.Throws<FabricObjectClosedException>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			// Act.
+			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			// If we are here, PublishAsync didn't explode.
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_WhenStatefulPartitionIsClosed_ReturnsGracefully()
+		{
+			// Arrange.
+			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
+			mockPartition.Setup(partition => partition.ReportReplicaHealth(It.IsAny<SfHealthInformation>()))
+				.Throws<FabricObjectClosedException>();
+			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
+			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+
+			// Act.
+			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			// If we are here, PublishAsync didn't explode.
+		}
+
+		private class HealthReportBuilder
+		{
+			private Dictionary<string, HealthReportEntry> Entries { get; } = new Dictionary<string, HealthReportEntry>();
+
+			private TimeSpan TotalDuration { get; set; }
+
+			public static HealthReport EmptyHealthReport { get; } = new HealthReport(new Dictionary<string, HealthReportEntry>(), totalDuration: default);
+
+			public HealthReportBuilder AddEntry(string healthCheckName, HealthStatus status)
+			{
+				HealthReportEntry entry = new HealthReportEntry(status, description: null, duration: default, exception: null, data: null, tags: null);
+				Entries.Add(healthCheckName, entry); // Health report shouldn't contain duplicate entries.
+				return this;
+			}
+
+			public HealthReportBuilder SetTotalDuration(TimeSpan totalDuration)
+			{
+				TotalDuration = totalDuration;
+				return this;
+			}
+
+			public HealthReport ToHealthReport()
+			{
+				return new HealthReport(Entries, TotalDuration);
+			}
 		}
 	}
 }

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
@@ -20,197 +20,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 	[TestClass]
 	public class ServiceFabricHealthCheckPublisherTests
 	{
-		private ILogger<ServiceFabricHealthCheckPublisher> NullLogger { get; } = new NullLogger<ServiceFabricHealthCheckPublisher>();
-
 		[TestMethod]
 		public async Task PublishAsync_WhenPartitionIsNotAvailable_ReturnsGracefully()
 		{
 			// Arrange.
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(null);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+			PublisherTestContext testContext = new PublisherTestContext();
 
 			// Act.
-			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
-
-			// Assert.
-			// If we are here, PublishAsync didn't explode.
-		}
-
-		[TestMethod]
-		public async Task PublishAsync_ForStatefulServicePartition_ReportsReplicaHealth()
-		{
-			// Arrange.
-			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Act.
-			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
-
-			// Assert.
-			mockPartition.Verify(partition => partition.ReportReplicaHealth(It.IsAny<SfHealthInformation>()));
-		}
-
-		[TestMethod]
-		public async Task PublishAsync_ForStatelessServicePartition_ReportsInstanceHealth()
-		{
-			// Arrange.
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Act.
-			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
-
-			// Assert.
-			mockPartition.Verify(partition => partition.ReportInstanceHealth(It.IsAny<SfHealthInformation>()));
-		}
-
-		[TestMethod]
-		public async Task PublishAsync_ForUnknownPartitionType_ThrowsArgumentException()
-		{
-			// Arrange.
-			Mock<IServicePartition> mockPartition = new Mock<IServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Act.
-			async Task act() => await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
-
-			// Assert.
-			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
-			string partitionTypeName = mockPartition.Object.GetType().ToString();
-			StringAssert.Contains(actualException.Message, partitionTypeName);
-		}
-
-		[DataTestMethod]
-		[DataRow("TestHealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
-		[DataRow("TestDegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
-		[DataRow("TestUnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
-		public async Task PublishAsync_ForHealthCheckWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
-		{
-			// Arrange.
-			SfHealthInformation? reportedSfHealthInformation = null;
-
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.Is<SfHealthInformation>(info => info.Property == healthCheckName)))
-				.Callback<SfHealthInformation>(info => reportedSfHealthInformation = info);
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			HealthReport report = new HealthReportBuilder()
-				.AddEntry(healthCheckName, healthCheckStatus)
-				.ToHealthReport();
-
-			// Act.
-			await publisher.PublishAsync(report, cancellationToken: default);
-
-			// Assert.
-			Assert.AreEqual(expectedSfHealthState, reportedSfHealthInformation?.HealthState);
-		}
-
-		[DataTestMethod]
-		[DataRow("NegativeInvalidStatusCheck", -1)]
-		[DataRow("PositiveInvalidStatusCheck", 3)]
-		public async Task PublishAsync_ForHealthCheckWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
-		{
-			// Arrange.
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			HealthReport report = new HealthReportBuilder()
-				.AddEntry(healthCheckName, invalidHealthCheckStatus)
-				.ToHealthReport();
-
-			// Act.
-			async Task act() => await publisher.PublishAsync(report, cancellationToken: default);
-
-			// Assert.
-			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
-			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
-		}
-
-		[DataTestMethod]
-		[DataRow("TestHealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
-		[DataRow("TestDegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
-		[DataRow("TestUnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
-		public async Task PublishAsync_ForReportWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
-		{
-			// Arrange.
-			SfHealthInformation? reportedSfHealthInformation = null;
-
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.Is<SfHealthInformation>(info => info.Property == ServiceFabricHealthCheckPublisher.HealthReportSummaryProperty)))
-				.Callback<SfHealthInformation>(info => reportedSfHealthInformation = info);
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Currently report status is calculated as the worst of all healthchecks. In .NET 5 it will be possible to set it independently.
-			HealthReport report = new HealthReportBuilder()
-				.AddEntry(healthCheckName, healthCheckStatus)
-				.ToHealthReport();
-
-			// Act.
-			await publisher.PublishAsync(report, cancellationToken: default);
-
-			// Assert.
-			Assert.AreEqual(expectedSfHealthState, reportedSfHealthInformation?.HealthState);
-		}
-
-		[DataTestMethod]
-		[DataRow("NegativeInvalidStatusCheck", -1)]
-		[DataRow("PositiveInvalidStatusCheck", 3)]
-		public async Task PublishAsync_ForReportWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
-		{
-			// Arrange.
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Currently report status is calculated as the worst of all entries. In .NET 5 it will be possible to set it independently.
-			HealthReport report = new HealthReportBuilder()
-				.AddEntry(healthCheckName, invalidHealthCheckStatus)
-				.ToHealthReport();
-
-			// Act.
-			async Task act() => await publisher.PublishAsync(report, cancellationToken: default);
-
-			// Assert.
-			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
-			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
-		}
-
-		[TestMethod]
-		public async Task PublishAsync_WhenCancellationTokenIsCancelled_ThrowsOperationCanceledException()
-		{
-			// Arrange.
-			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			CancellationTokenSource tokenSource = new CancellationTokenSource();
-			tokenSource.Cancel();
-
-			// Act.
-			async Task act() => await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, tokenSource.Token);
-
-			// Assert.
-			OperationCanceledException actualException = await Assert.ThrowsExceptionAsync<OperationCanceledException>(act);
-		}
-
-		[TestMethod]
-		public async Task PublishAsync_WhenStatelessPartitionIsClosed_ReturnsGracefully()
-		{
-			// Arrange.
-			Mock<IStatelessServicePartition> mockPartition = new Mock<IStatelessServicePartition>();
-			mockPartition.Setup(partition => partition.ReportInstanceHealth(It.IsAny<SfHealthInformation>()))
-				.Throws<FabricObjectClosedException>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
-
-			// Act.
-			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+			await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
 			// Assert.
 			// If we are here, PublishAsync didn't explode.
@@ -220,17 +37,246 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		public async Task PublishAsync_WhenStatefulPartitionIsClosed_ReturnsGracefully()
 		{
 			// Arrange.
-			Mock<IStatefulServicePartition> mockPartition = new Mock<IStatefulServicePartition>();
-			mockPartition.Setup(partition => partition.ReportReplicaHealth(It.IsAny<SfHealthInformation>()))
-				.Throws<FabricObjectClosedException>();
-			Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(mockPartition.Object);
-			ServiceFabricHealthCheckPublisher publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatefulServicePartition(closed: true);
 
 			// Act.
-			await publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+			await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
 
 			// Assert.
 			// If we are here, PublishAsync didn't explode.
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_WhenStatelessPartitionIsClosed_ReturnsGracefully()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatelessServicePartition(closed: true);
+
+			// Act.
+			await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			// If we are here, PublishAsync didn't explode.
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_ForStatefulServicePartition_ReportsReplicaHealth()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatefulServicePartition();
+
+			// Act.
+			await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			testContext.MockStatefulServicePartition!.Verify(partition => partition.ReportReplicaHealth(It.IsAny<SfHealthInformation>()));
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_ForStatelessServicePartition_ReportsInstanceHealth()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatelessServicePartition();
+
+			// Act.
+			await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			testContext.MockStatelessServicePartition!.Verify(partition => partition.ReportInstanceHealth(It.IsAny<SfHealthInformation>()));
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_ForUnknownPartitionType_ThrowsArgumentException()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureServicePartition();
+
+			// Act.
+			async Task act() => await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, cancellationToken: default);
+
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			string partitionTypeName = testContext.MockServicePartition!.Object.GetType().ToString();
+			StringAssert.Contains(actualException.Message, partitionTypeName);
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_WhenCancellationIsRequested_ThrowsOperationCanceledException()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatefulServicePartition();
+
+			CancellationTokenSource tokenSource = new CancellationTokenSource();
+			tokenSource.Cancel();
+
+			// Act.
+			async Task act() => await testContext.Publisher.PublishAsync(HealthReportBuilder.EmptyHealthReport, tokenSource.Token);
+
+			// Assert.
+			await Assert.ThrowsExceptionAsync<OperationCanceledException>(act);
+		}
+
+		[DataTestMethod]
+		[DataRow("HealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
+		[DataRow("DegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
+		[DataRow("UnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
+		public async Task PublishAsync_ForHealthCheckWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatelessServicePartition();
+
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, healthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			await testContext.Publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			Assert.AreEqual(expectedSfHealthState, testContext.ReportedSfHealthInformation(healthCheckName)?.HealthState);
+		}
+
+		[DataTestMethod]
+		[DataRow("NegativeInvalidStatusCheck", -1)]
+		[DataRow("PositiveInvalidStatusCheck", 3)]
+		public async Task PublishAsync_ForHealthCheckWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatefulServicePartition();
+
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, invalidHealthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			async Task act() => await testContext.Publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
+		}
+
+		[DataTestMethod]
+		[DataRow("HealthyCheck", HealthStatus.Healthy, SfHealthState.Ok)]
+		[DataRow("DegradedCheck", HealthStatus.Degraded, SfHealthState.Warning)]
+		[DataRow("UnhealthyCheck", HealthStatus.Unhealthy, SfHealthState.Error)]
+		public async Task PublishAsync_ForReportWithValidHealthStatus_ReportsCorrectSfHealthState(string healthCheckName, HealthStatus healthCheckStatus, SfHealthState expectedSfHealthState)
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatefulServicePartition();
+
+			// Currently report status is calculated as the worst of all healthchecks. In .NET 5 it will be possible to set it independently.
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, healthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			await testContext.Publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			Assert.AreEqual(expectedSfHealthState, testContext.ReportedSfHealthInformation(ServiceFabricHealthCheckPublisher.HealthReportSummaryProperty)?.HealthState);
+		}
+
+		[DataTestMethod]
+		[DataRow("NegativeInvalidStatusCheck", -1)]
+		[DataRow("PositiveInvalidStatusCheck", 3)]
+		public async Task PublishAsync_ForReportWithInvalidHealthStatus_ThrowsArgumentException(string healthCheckName, HealthStatus invalidHealthCheckStatus)
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatelessServicePartition();
+
+			// Currently report status is calculated as the worst of all entries. In .NET 5 it will be possible to set it independently.
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthCheckName, invalidHealthCheckStatus)
+				.ToHealthReport();
+
+			// Act.
+			async Task act() => await testContext.Publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			ArgumentException actualException = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+			StringAssert.Contains(actualException.Message, invalidHealthCheckStatus.ToString());
+		}
+
+		[TestMethod]
+		public async Task PublishAsync_ForValidReportWithSeveralEntries_ReportsCorrectSfHealthInformation()
+		{
+			// Arrange.
+			PublisherTestContext testContext = new PublisherTestContext();
+			testContext.ConfigureStatelessServicePartition();
+
+			string healthyCheckName = "HealthyCheck";
+			HealthReportEntry healthyEntry = new HealthReportEntry(
+				status: HealthStatus.Healthy,
+				description: "Healthy entry description",
+				duration: TimeSpan.FromMilliseconds(12639),
+				exception: null,
+				data: null);
+
+			string degradedCheckName = "DegradedCheck";
+			HealthReportEntry degradedEntry = new HealthReportEntry(
+				status: HealthStatus.Degraded,
+				description: "Degraded entry description",
+				duration: TimeSpan.FromMilliseconds(111),
+				exception: null,
+				data: null);
+
+			string unhealthyCheckName = "UnhealthyCheck";
+			HealthReportEntry unhealthyEntry = new HealthReportEntry(
+				status: HealthStatus.Unhealthy,
+				description: "Unhealthy entry description",
+				duration: TimeSpan.FromMilliseconds(73),
+				exception: new InvalidOperationException("Unhealthy check performed invalid operation."),
+				data: null);
+
+			HealthReport report = new HealthReportBuilder()
+				.AddEntry(healthyCheckName, healthyEntry)
+				.AddEntry(degradedCheckName, degradedEntry)
+				.AddEntry(unhealthyCheckName, unhealthyEntry)
+				.SetTotalDuration(TimeSpan.FromSeconds(72))
+				.ToHealthReport();
+
+			// Act.
+			await testContext.Publisher.PublishAsync(report, cancellationToken: default);
+
+			// Assert.
+			SfHealthInformation? healthyInfo = testContext.ReportedSfHealthInformation(healthyCheckName);
+			Assert.AreEqual(ServiceFabricHealthCheckPublisher.HealthReportSourceId, healthyInfo?.SourceId, "SourceId from healthy check is incorrect.");
+			Assert.AreEqual(healthyCheckName, healthyInfo?.Property, "Property from healthy check is incorrect.");
+			Assert.AreEqual(SfHealthState.Ok, healthyInfo?.HealthState, "HealthState from healthy check is incorrect.");
+			StringAssert.Contains(healthyInfo?.Description ?? string.Empty, healthyEntry.Description, "Description from healthy check is not included.");
+			StringAssert.Contains(healthyInfo?.Description ?? string.Empty, healthyEntry.Duration.ToString(), "Duration from healthy check is not included.");
+
+			SfHealthInformation? degradedInfo = testContext.ReportedSfHealthInformation(degradedCheckName);
+			Assert.AreEqual(ServiceFabricHealthCheckPublisher.HealthReportSourceId, degradedInfo?.SourceId, "SourceId from degraded check is incorrect.");
+			Assert.AreEqual(degradedCheckName, degradedInfo?.Property, "Property from degraded check is incorrect.");
+			Assert.AreEqual(SfHealthState.Warning, degradedInfo?.HealthState, "HealthState from degraded check is incorrect.");
+			StringAssert.Contains(degradedInfo?.Description ?? string.Empty, degradedEntry.Description, "Description from degraded check is not included.");
+			StringAssert.Contains(degradedInfo?.Description ?? string.Empty, degradedEntry.Duration.ToString(), "Duration from degraded check is not included.");
+
+			SfHealthInformation? unhealthyInfo = testContext.ReportedSfHealthInformation(unhealthyCheckName);
+			Assert.AreEqual(ServiceFabricHealthCheckPublisher.HealthReportSourceId, unhealthyInfo?.SourceId, "SourceId from unhealthy check is incorrect.");
+			Assert.AreEqual(unhealthyCheckName, unhealthyInfo?.Property, "Property from unhealthy check is incorrect.");
+			Assert.AreEqual(SfHealthState.Error, unhealthyInfo?.HealthState, "HealthState from unhealthy check is incorrect.");
+			StringAssert.Contains(unhealthyInfo?.Description ?? string.Empty, unhealthyEntry.Description, "Description from unhealthy check is not included.");
+			StringAssert.Contains(unhealthyInfo?.Description ?? string.Empty, unhealthyEntry.Duration.ToString(), "Duration from unhealthy check is not included.");
+			StringAssert.Contains(unhealthyInfo?.Description ?? string.Empty, unhealthyEntry.Exception.GetType().ToString(), "Exception from unhealthy check is not included.");
+
+			SfHealthInformation? summaryInfo = testContext.ReportedSfHealthInformation(ServiceFabricHealthCheckPublisher.HealthReportSummaryProperty);
+			Assert.AreEqual(ServiceFabricHealthCheckPublisher.HealthReportSourceId, summaryInfo?.SourceId, "SourceId from report is incorrect.");
+			Assert.AreEqual(ServiceFabricHealthCheckPublisher.HealthReportSummaryProperty, summaryInfo?.Property, "Property from report is incorrect.");
+			Assert.AreEqual(SfHealthState.Error, summaryInfo?.HealthState, "HealthState from report is incorrect.");
+			StringAssert.Contains(summaryInfo?.Description ?? string.Empty, report.TotalDuration.ToString(), "TotalDuration from report is not included.");
 		}
 
 		private class HealthReportBuilder
@@ -243,8 +289,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 
 			public HealthReportBuilder AddEntry(string healthCheckName, HealthStatus status)
 			{
-				HealthReportEntry entry = new HealthReportEntry(status, description: null, duration: default, exception: null, data: null, tags: null);
-				Entries.Add(healthCheckName, entry); // Health report shouldn't contain duplicate entries.
+				HealthReportEntry entry = new HealthReportEntry(status, description: null, duration: default, exception: null, data: null);
+				Entries.Add(healthCheckName, entry); // Health report shouldn't contain duplicate health check names.
+				return this;
+			}
+
+			public HealthReportBuilder AddEntry(string healthCheckName, HealthReportEntry entry)
+			{
+				Entries.Add(healthCheckName, entry);
 				return this;
 			}
 
@@ -254,10 +306,75 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 				return this;
 			}
 
-			public HealthReport ToHealthReport()
+			public HealthReport ToHealthReport() => new HealthReport(Entries, TotalDuration);
+		}
+
+		private class PublisherTestContext
+		{
+			public PublisherTestContext()
 			{
-				return new HealthReport(Entries, TotalDuration);
+				// Partition is not available by default.
+				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(null);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
 			}
+
+			public void ConfigureStatefulServicePartition(bool closed = false)
+			{
+				MockStatefulServicePartition = new Mock<IStatefulServicePartition>();
+				MockStatefulServicePartition.Setup(_ => _.ReportReplicaHealth(It.IsAny<SfHealthInformation>()))
+					.Callback<SfHealthInformation>(info =>
+					{
+						if (closed)
+						{
+							throw new FabricObjectClosedException();
+						}
+
+						m_reportedSfHealthInformation[info.Property] = info;
+					});
+				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatefulServicePartition.Object);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+			}
+
+			public void ConfigureStatelessServicePartition(bool closed = false)
+			{
+				MockStatelessServicePartition = new Mock<IStatelessServicePartition>();
+				MockStatelessServicePartition.Setup(_ => _.ReportInstanceHealth(It.IsAny<SfHealthInformation>()))
+					.Callback<SfHealthInformation>(info =>
+					{
+						if (closed)
+						{
+							throw new FabricObjectClosedException();
+						}
+
+						m_reportedSfHealthInformation[info.Property] = info;
+					});
+				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatelessServicePartition.Object);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+			}
+
+			public void ConfigureServicePartition()
+			{
+				MockServicePartition = new Mock<IServicePartition>();
+				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockServicePartition.Object);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+			}
+
+			public Mock<IStatefulServicePartition>? MockStatefulServicePartition { get; private set; }
+
+			public Mock<IStatelessServicePartition>? MockStatelessServicePartition { get; private set; }
+
+			public Mock<IServicePartition>? MockServicePartition { get; private set; }
+
+			public ServiceFabricHealthCheckPublisher Publisher { get; private set; }
+
+			public SfHealthInformation? ReportedSfHealthInformation(string propertyName) =>
+				m_reportedSfHealthInformation.ContainsKey(propertyName)
+					? m_reportedSfHealthInformation[propertyName]
+					: null;
+
+			private Dictionary<string, SfHealthInformation> m_reportedSfHealthInformation = new Dictionary<string, SfHealthInformation>();
+
+			private static ILogger<ServiceFabricHealthCheckPublisher> NullLogger { get; } = new NullLogger<ServiceFabricHealthCheckPublisher>();
 		}
 	}
 }


### PR DESCRIPTION
Health checks results are now reported at instance/replica level. HealthInformation formatting is improved. Some bugs fixed. Working on unit tests now.