### PR TITLE
Switched SF health check publisher to StringBuilder pool.

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -22,18 +22,19 @@
     <Xunit_Core_Version>2.4.1</Xunit_Core_Version>
   </PropertyGroup>
   <PropertyGroup Label="Packages for Omex Extensions. AutoUpdate">
-    <Microsoft_Extensions_Hosting_Abstractions_Version>3.1.8</Microsoft_Extensions_Hosting_Abstractions_Version>
-    <Microsoft_Extensions_Hosting_Version>3.1.8</Microsoft_Extensions_Hosting_Version>
-    <Microsoft_Extensions_Logging_Abstractions_Version>3.1.8</Microsoft_Extensions_Logging_Abstractions_Version>
-    <Microsoft_Extensions_DependencyInjection_Abstractions_Version>3.1.8</Microsoft_Extensions_DependencyInjection_Abstractions_Version>
-    <Microsoft_Extensions_Logging_Version>3.1.8</Microsoft_Extensions_Logging_Version>
-    <Microsoft_Extensions_Logging_Console_Version>3.1.8</Microsoft_Extensions_Logging_Console_Version>
     <Microsoft_Extensions_DependencyInjection_Version>3.1.8</Microsoft_Extensions_DependencyInjection_Version>
-    <Microsoft_Extensions_Options_Version>3.1.8</Microsoft_Extensions_Options_Version>
+    <Microsoft_Extensions_DependencyInjection_Abstractions_Version>3.1.8</Microsoft_Extensions_DependencyInjection_Abstractions_Version>
     <Microsoft_Extensions_Diagnostics_HealthChecks_Version>3.1.8</Microsoft_Extensions_Diagnostics_HealthChecks_Version>
+    <Microsoft_Extensions_Hosting_Version>3.1.8</Microsoft_Extensions_Hosting_Version>
+    <Microsoft_Extensions_Hosting_Abstractions_Version>3.1.8</Microsoft_Extensions_Hosting_Abstractions_Version>
     <Microsoft_Extensions_Http_Version>3.1.8</Microsoft_Extensions_Http_Version>
-    <System_Threading_Tasks_Extensions_Version>4.5.4</System_Threading_Tasks_Extensions_Version>
+    <Microsoft_Extensions_Logging_Version>3.1.8</Microsoft_Extensions_Logging_Version>
+    <Microsoft_Extensions_Logging_Abstractions_Version>3.1.8</Microsoft_Extensions_Logging_Abstractions_Version>
+    <Microsoft_Extensions_Logging_Console_Version>3.1.8</Microsoft_Extensions_Logging_Console_Version>
+    <Microsoft_Extensions_ObjectPool_Version>3.1.8</Microsoft_Extensions_ObjectPool_Version>
+    <Microsoft_Extensions_Options_Version>3.1.8</Microsoft_Extensions_Options_Version>
     <System_Diagnostics_DiagnosticSource_Version>5.0.0-rc.1.20451.14</System_Diagnostics_DiagnosticSource_Version>
+    <System_Threading_Tasks_Extensions_Version>4.5.4</System_Threading_Tasks_Extensions_Version>
   </PropertyGroup>
   <PropertyGroup Label="ServiceFabric packages for Omex Extensions">
     <Microsoft_ServiceFabric_Version>7.1.456</Microsoft_ServiceFabric_Version>

--- a/src/Extensions/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Extensions/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -5,8 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(Microsoft_ServiceFabric_Version)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(Microsoft_Extensions_Http_Version)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(Microsoft_Extensions_Diagnostics_HealthChecks_Version)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(Microsoft_Extensions_Http_Version)" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(Microsoft_Extensions_ObjectPool_Version)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/src/Extensions/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
@@ -27,6 +28,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 					Credentials = CredentialCache.DefaultCredentials,
 					ServerCertificateCustomValidationCallback = (sender, x509Certificate, chain, errors) => true
 				});
+
+			serviceCollection.TryAddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
 
 			return serviceCollection
 				.AddHealthCheckPublisher<ServiceFabricHealthCheckPublisher>()

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			{
 				// Partition is not available by default.
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(null);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, ObjectPoolProvider);
 			}
 
 			public void ConfigureStatefulServicePartition(bool closed = false)
@@ -333,7 +333,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 						m_reportedSfHealthInformation[info.Property] = info;
 					});
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatefulServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, ObjectPoolProvider);
 			}
 
 			public void ConfigureStatelessServicePartition(bool closed = false)
@@ -350,14 +350,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 						m_reportedSfHealthInformation[info.Property] = info;
 					});
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatelessServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, ObjectPoolProvider);
 			}
 
 			public void ConfigureServicePartition()
 			{
 				MockServicePartition = new Mock<IServicePartition>();
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, ObjectPoolProvider);
 			}
 
 			public Mock<IStatefulServicePartition>? MockStatefulServicePartition { get; private set; }
@@ -376,6 +376,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			private readonly Dictionary<string, SfHealthInformation> m_reportedSfHealthInformation = new Dictionary<string, SfHealthInformation>();
 
 			private static ILogger<ServiceFabricHealthCheckPublisher> NullLogger { get; } = new NullLogger<ServiceFabricHealthCheckPublisher>();
+
+			private static ObjectPoolProvider ObjectPoolProvider { get; } = new DefaultObjectPoolProvider();
 		}
 	}
 }

--- a/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
+++ b/tests/Extensions/Diagnostics.HealthChecks.UnitTests/ServiceFabricHealthCheckPublisherTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.ObjectPool;
 using Microsoft.Omex.Extensions.Abstractions.Accessors;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -315,7 +316,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			{
 				// Partition is not available by default.
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(null);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
 			}
 
 			public void ConfigureStatefulServicePartition(bool closed = false)
@@ -332,7 +333,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 						m_reportedSfHealthInformation[info.Property] = info;
 					});
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatefulServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
 			}
 
 			public void ConfigureStatelessServicePartition(bool closed = false)
@@ -349,14 +350,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 						m_reportedSfHealthInformation[info.Property] = info;
 					});
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockStatelessServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
 			}
 
 			public void ConfigureServicePartition()
 			{
 				MockServicePartition = new Mock<IServicePartition>();
 				Accessor<IServicePartition> partitionAccessor = new Accessor<IServicePartition>(MockServicePartition.Object);
-				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger);
+				Publisher = new ServiceFabricHealthCheckPublisher(partitionAccessor, NullLogger, new DefaultObjectPoolProvider());
 			}
 
 			public Mock<IStatefulServicePartition>? MockStatefulServicePartition { get; private set; }
@@ -372,7 +373,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 					? m_reportedSfHealthInformation[propertyName]
 					: null;
 
-			private Dictionary<string, SfHealthInformation> m_reportedSfHealthInformation = new Dictionary<string, SfHealthInformation>();
+			private readonly Dictionary<string, SfHealthInformation> m_reportedSfHealthInformation = new Dictionary<string, SfHealthInformation>();
 
 			private static ILogger<ServiceFabricHealthCheckPublisher> NullLogger { get; } = new NullLogger<ServiceFabricHealthCheckPublisher>();
 		}


### PR DESCRIPTION
Each health check was creating a new StringBuilder on each publish. I siwtched to pooled StringBuilders to decrease allocations, that should give us some perf boost.