### PR TITLE
Version logging fix

### DIFF
--- a/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -112,8 +112,10 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 		/// </summary>
 		protected static string GetBuildVersion()
 		{
-			FileVersionInfo buildVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
-			return string.Concat(buildVersion.FileBuildPart, ".", buildVersion.FilePrivatePart);
+			Assembly? assembly = Assembly.GetEntryAssembly();
+			return assembly != null
+				? FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion
+				: DefaultEmptyValue;
 		}
 
 		/// <summary>

--- a/tests/Extensions/Hosting.Services.UnitTests/ServiceFabricExecutionContextTests.cs
+++ b/tests/Extensions/Hosting.Services.UnitTests/ServiceFabricExecutionContextTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Fabric;
 using System.Net;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Omex.Extensions.Abstractions.Accessors;
 using Microsoft.Omex.Extensions.Abstractions.ExecutionContext;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -27,12 +29,17 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 			Environment.SetEnvironmentVariable(ServiceFabricExecutionContext.NodeNameVariableName, nodeName);
 			Environment.SetEnvironmentVariable(ServiceFabricExecutionContext.NodeIPOrFQDNVariableName, nodeIPOrFQDN.ToString());
 
-			IExecutionContext info = new ServiceFabricExecutionContext(new Mock<IHostEnvironment>().Object);
+			ServiceContext context = MockStatelessServiceContextFactory.Default;
+			Accessor<ServiceContext> accessor = new Accessor<ServiceContext>();
+			((IAccessorSetter<ServiceContext>)accessor).SetValue(context);
+
+			IExecutionContext info = new ServiceFabricExecutionContext(new Mock<IHostEnvironment>().Object, accessor);
 
 			Assert.AreEqual(applicationName, info.ApplicationName);
 			Assert.AreEqual(serviceName, info.ServiceName);
 			StringAssert.Contains(info.MachineId, nodeName);
 			Assert.AreEqual(nodeIPOrFQDN, info.ClusterIpAddress);
+			Assert.AreEqual(context.CodePackageActivationContext.CodePackageVersion, info.BuildVersion);
 		}
 	}
 }


### PR DESCRIPTION
Version logic will be taking version from entry assembly by default
For SF services it will use the version from CodePackage until all services not updated to set the version of the executable properly