### PR TITLE
Add Diagnostics to HttpClient

### DIFF
--- a/src/Extensions/Activities/Internal/DiagnosticsListener/DiagnosticsObserversInitializer.cs
+++ b/src/Extensions/Activities/Internal/DiagnosticsListener/DiagnosticsObserversInitializer.cs
@@ -31,11 +31,14 @@ namespace Microsoft.Omex.Extensions.Activities
 		private static readonly string[] s_eventEndMarkersToListen = new[] {
 			ExceptionEventEnding,
 			// We need to listen for the "Microsoft.AspNetCore.Hosting.HttpRequestIn" event in order to signal Kestrel to create an Activity for the incoming http request.
-			// Searching only for RequestIn, in case any other requests follow the same pattern
+			// Searching only for RequestIn, in case any other requests follow the same pattern (ex. Omex Remoting)
 			"RequestIn",
 			// We need to listen for the "System.Net.Http.HttpRequestOut" event in order to create an Activity for the outgoing http requests.
-			// Searching only for RequestOut, in case any other requests follow the same pattern
-			"RequestOut"
+			// Searching only for RequestOut, in case any other requests follow the same pattern (ex. Omex Remoting)
+			"RequestOut",
+			// Subscribe to ask HttpClient to create Activity on outgoing request
+			// https://github.com/dotnet/runtime/blob/1d9e50cb4735df46d3de0cee5791e97295eaf588/src/libraries/System.Net.Http/src/HttpDiagnosticsGuide.md#subscription
+			"HttpHandlerDiagnosticListener"
 		};
 
 		private static bool EventEndsWith(string eventName, string ending) => eventName.EndsWith(ending, StringComparison.Ordinal);

--- a/tests/Extensions/Activities.UnitTests/Internal/DiagnosticsObserversInitializerTests.cs
+++ b/tests/Extensions/Activities.UnitTests/Internal/DiagnosticsObserversInitializerTests.cs
@@ -55,6 +55,7 @@ namespace Hosting.Services.UnitTests
 
 				using DiagnosticListener listener = new DiagnosticListener(name);
 
+				AssertEnabledFor(listener, HttpClientListenerName);
 				AssertEnabledFor(listener, HttpRequestOutEventName);
 				AssertEnabledFor(listener, HttpRequestInEventName);
 				AssertEnabledFor(listener, ExceptionEventName);
@@ -76,6 +77,8 @@ namespace Hosting.Services.UnitTests
 			Assert.IsTrue(listener.IsEnabled(eventName), "Should be enabled for '{0}'", eventName);
 
 		private const string ExceptionEventName = "System.Net.Http.Exception";
+
+		private const string HttpClientListenerName = "HttpHandlerDiagnosticListener";
 
 		private const string HttpRequestOutEventName = "System.Net.Http.HttpRequestOut";
 


### PR DESCRIPTION
Currently, HttpClient would add `Activity` to outgoing request if it's running inside of the `Activity`, with this change it would create new Activity for outgoing request if it does not exist.