### PR TITLE
Enabling optional gate generation

### DIFF
--- a/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
+++ b/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
@@ -26,7 +26,7 @@
 		<Error Text="The TipXml property is not defined." Condition="'$(TipXml)' == ''" />
 		<Error Text="The GeneratedGates property is not defined." Condition="'$(GeneratedGates)' == ''" />
 
-		<Exec Command="dotnet $(MSBuildThisFileDirectory)..\tools\Microsoft.Omex.CodeGenerators.GateGen.dll $(GatesXml) $(TipXml) $(GeneratedGates) $(OmexGatesNamespace)" />
+		<Exec Command="dotnet $(MSBuildThisFileDirectory)..\tools\Microsoft.Omex.CodeGenerators.GateGen.dll $(GatesXml) $(TipXml) $(GeneratedGates) $(OmexGatesNamespace) $(UseGateGen)" />
 
 		<CreateItem Include="$(GeneratedGates)">
 			<Output TaskParameter="Include" ItemName="Compile"/>

--- a/src/CodeGenerators/GateGen/Program.cs
+++ b/src/CodeGenerators/GateGen/Program.cs
@@ -35,6 +35,16 @@ namespace Microsoft.Omex.CodeGenerators.GateGen
 					return 1;
 				}
 
+				// Check if UseGateGen value is provided
+				if (arguments.Length >= 4)
+				{
+					if (bool.TryParse(arguments[3], out bool useGateGen) && !useGateGen)
+					{
+						Console.WriteLine("UseGateGen set to false, not generating gates");
+						return 0;
+					}
+				}
+
 				GateDataSet gateDataSet = null;
 				try
 				{

--- a/src/CodeGenerators/GateGen/Program.cs
+++ b/src/CodeGenerators/GateGen/Program.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Omex.CodeGenerators.GateGen
 				}
 
 				// Check if UseGateGen value is provided
-				if (arguments.Length >= 4)
+				if (arguments.Length >= 5)
 				{
-					if (bool.TryParse(arguments[3], out bool useGateGen) && !useGateGen)
+					if (bool.TryParse(arguments[4], out bool useGateGen) && !useGateGen)
 					{
 						Console.WriteLine("UseGateGen set to false, not generating gates");
 						return 0;


### PR DESCRIPTION
This is to fix an issue where the UseGateGen property is not used by the gate generation tool. Now if provided it will not generate on false. For compatibility if no UseGateGen is provided it will generate it by default