### PR TITLE
Converted TryWriteBytes in ident provider to async

### DIFF
--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
@@ -19,6 +20,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		/// <summary>
 		/// Tries to extract user information for HttpContext to create user hash
 		/// </summary>
-		public bool TryWriteBytes(HttpContext context, Span<byte> span, out int bytesWritten);
+		public Task<bool> TryWriteBytesAsync(HttpContext context, Span<byte> span, out int bytesWritten);
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -12,14 +13,14 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	{
 		public int MaxBytesInIdentity { get; } = 16; // IPv6 size, from here https://github.com/dotnet/runtime/blob/26a71f95b708721065f974fd43ba82a1dcb3e8f0/src/libraries/Common/src/System/Net/IPAddressParserStatics.cs#L9
 
-		public bool TryWriteBytes(HttpContext context, Span<byte> span, out int bytesWritten)
+		public Task<bool> TryWriteBytesAsync(HttpContext context, Span<byte> span, out int bytesWritten)
 		{
 			bytesWritten = -1;
 			IHttpConnectionFeature connection = context.Features.Get<IHttpConnectionFeature>();
 			IPAddress? remoteIpAddress = connection.RemoteIpAddress;
 
-			return remoteIpAddress != null
-				&& remoteIpAddress.TryWriteBytes(span, out bytesWritten);
+			return Task.FromResult(remoteIpAddress != null
+				&& remoteIpAddress.TryWriteBytes(span, out bytesWritten));
 		}
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentiyMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentiyMiddleware.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 
 			if (activity != null && string.IsNullOrEmpty(activity.GetUserHash()))
 			{
-				string userHash = await CreateUserHash(context).ConfigureAwait(false);
+				string userHash = await CreateUserHashAsync(context).ConfigureAwait(false);
 				if (!string.IsNullOrWhiteSpace(userHash))
 				{
 					activity.SetUserHash(userHash);
@@ -46,7 +46,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			await next(context);
 		}
 
-		internal async Task<string> CreateUserHash(HttpContext context)
+		internal async Task<string> CreateUserHashAsync(HttpContext context)
 		{
 			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent(m_maxIdentitySize + m_saltProvider.GetSalt().Length);
 

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,12 +13,12 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 	public class IpBasedUserIdentityProviderTests
 	{
 		[TestMethod]
-		public void TryWriteBytes_ReturnFalseIfNoIpAddress()
+		public async Task TryWriteBytes_ReturnFalseIfNoIpAddress()
 		{
 			IUserIdentityProvider provider = new IpBasedUserIdentityProvider();
 			(HttpContext context, _) = HttpContextHelper.CreateHttpContext();
 
-			bool result = provider.TryWriteBytes(context, new byte[provider.MaxBytesInIdentity].AsSpan(), out int bytesWritten);
+			bool result = await provider.TryWriteBytesAsync(context, new byte[provider.MaxBytesInIdentity].AsSpan(), out int bytesWritten).ConfigureAwait(false);
 			Assert.IsFalse(result);
 			Assert.AreEqual(-1, bytesWritten);
 		}
@@ -41,7 +42,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 		private static byte[] GetIdentity(IUserIdentityProvider provider, HttpContext context)
 		{
 			byte[] array = new byte[provider.MaxBytesInIdentity];
-			provider.TryWriteBytes(context, array.AsSpan(), out int bytes);
+			provider.TryWriteBytesAsync(context, array.AsSpan(), out int bytes);
 			Assert.IsTrue(provider.MaxBytesInIdentity >= bytes, "Written size bigger then max size");
 			return array;
 		}

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 			UserHashIdentityMiddleware middleware = GetMiddelware(saltProvider: saltProvider);
 
 			HttpContext context = HttpContextHelper.GetContextWithIp("192.168.100.1");
-			string initialHash = await middleware.CreateUserHash(context).ConfigureAwait(false);
+			string initialHash = await middleware.CreateUserHashAsync(context).ConfigureAwait(false);
 
 			random.NextBytes(saltProvider.Salt);
-			string changedHash = await middleware.CreateUserHash(context).ConfigureAwait(false);
+			string changedHash = await middleware.CreateUserHashAsync(context).ConfigureAwait(false);
 
 			Assert.AreNotEqual(changedHash, initialHash);
 		}
@@ -74,7 +74,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 				.Select(async index =>
 				{
 					int contextIndex = index % contexts.Length;
-					string hash = await middleware.CreateUserHash(contexts[contextIndex]).ConfigureAwait(false);
+					string hash = await middleware.CreateUserHashAsync(contexts[contextIndex]).ConfigureAwait(false);
 					return (contextIndex, hash);
 				});
 			(int contextIndex, string hash)[] tupleList = await Task.WhenAll(result).ConfigureAwait(false);
@@ -98,7 +98,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 			TestIdentityProvider mock2 = new ("Procider2", 10) { IsApplicable = secondApplicable };
 			UserHashIdentityMiddleware middleware = GetMiddelware(saltProvider: null, mock1, mock2);
 
-			string hash = await middleware.CreateUserHash(context).ConfigureAwait(false);
+			string hash = await middleware.CreateUserHashAsync(context).ConfigureAwait(false);
 			mock1.AssertCallsAndReset(firstShouldBeCalled);
 			mock2.AssertCallsAndReset(secondShouldBeCalled);
 

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Omex.Extensions.Abstractions.Activities;
 using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using System.Collections.Generic;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 {


### PR DESCRIPTION
Converted TryWriteBytes in ident provider to async method.
Have updated the unit tests accordingly. This is done to allow it to async methods in its implementation