### PR TITLE
Converting ref in async to tuple return

### DIFF
--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		/// <summary>
 		/// Tries to extract user information for HttpContext to create user hash
 		/// </summary>
-		public Task<bool> TryWriteBytesAsync(HttpContext context, Span<byte> span, out int bytesWritten);
+		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span);
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	{
 		public int MaxBytesInIdentity { get; } = 16; // IPv6 size, from here https://github.com/dotnet/runtime/blob/26a71f95b708721065f974fd43ba82a1dcb3e8f0/src/libraries/Common/src/System/Net/IPAddressParserStatics.cs#L9
 
-		public Task<bool> TryWriteBytesAsync(HttpContext context, Span<byte> span, out int bytesWritten)
+		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span)
 		{
-			bytesWritten = -1;
+			int bytesWritten = -1;
 			IHttpConnectionFeature connection = context.Features.Get<IHttpConnectionFeature>();
 			IPAddress? remoteIpAddress = connection.RemoteIpAddress;
 
-			return Task.FromResult(remoteIpAddress != null
-				&& remoteIpAddress.TryWriteBytes(span, out bytesWritten));
+			return Task.FromResult((remoteIpAddress != null
+				&& remoteIpAddress.TryWriteBytes(span, out bytesWritten), bytesWritten));
 		}
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentiyMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentiyMiddleware.cs
@@ -56,8 +56,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			int identityBytesWritten = -1;
 			foreach (IUserIdentityProvider provider in m_userIdentityProviders)
 			{
-				if (await provider.TryWriteBytesAsync(context, uidMemoryOwner.Memory.Span.Slice(0, provider.MaxBytesInIdentity), out identityBytesWritten)
-					.ConfigureAwait(false))
+				bool success;
+				(success, identityBytesWritten) = await provider.TryWriteBytesAsync(context, uidMemoryOwner.Memory.Span.Slice(0, provider.MaxBytesInIdentity))
+					.ConfigureAwait(false);
+				if (success)
 				{
 					break;
 				}

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
@@ -18,31 +18,31 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 			IUserIdentityProvider provider = new IpBasedUserIdentityProvider();
 			(HttpContext context, _) = HttpContextHelper.CreateHttpContext();
 
-			bool result = await provider.TryWriteBytesAsync(context, new byte[provider.MaxBytesInIdentity].AsSpan(), out int bytesWritten).ConfigureAwait(false);
+			(bool result, int bytesWritten) = await provider.TryWriteBytesAsync(context, new byte[provider.MaxBytesInIdentity].AsSpan()).ConfigureAwait(false);
 			Assert.IsFalse(result);
 			Assert.AreEqual(-1, bytesWritten);
 		}
 
 		[TestMethod]
-		public void TryWriteBytes_ChangedBaseOnIpAddress()
+		public async Task TryWriteBytes_ChangedBaseOnIpAddress()
 		{
 			IUserIdentityProvider provider = new IpBasedUserIdentityProvider();
 
 			HttpContext context1 = HttpContextHelper.GetContextWithIp("192.168.0.2");
 			HttpContext context2 = HttpContextHelper.GetContextWithIp("127.0.0.2");
 
-			byte[] hash1 = GetIdentity(provider, context1);
-			byte[] hash2 = GetIdentity(provider, context2);
+			byte[] hash1 = await GetIdentityAsync(provider, context1).ConfigureAwait(false);
+			byte[] hash2 = await GetIdentityAsync(provider, context2).ConfigureAwait(false);
 
 			CollectionAssert.AreNotEqual(hash1, hash2);
-			CollectionAssert.AreEqual(hash1, GetIdentity(provider, context1));
-			CollectionAssert.AreEqual(hash2, GetIdentity(provider, context2));
+			CollectionAssert.AreEqual(hash1, await GetIdentityAsync(provider, context1).ConfigureAwait(false));
+			CollectionAssert.AreEqual(hash2, await GetIdentityAsync(provider, context2).ConfigureAwait(false));
 		}
 
-		private static byte[] GetIdentity(IUserIdentityProvider provider, HttpContext context)
+		private async Task<byte[]> GetIdentityAsync(IUserIdentityProvider provider, HttpContext context)
 		{
 			byte[] array = new byte[provider.MaxBytesInIdentity];
-			provider.TryWriteBytesAsync(context, array.AsSpan(), out int bytes);
+			(bool success, int bytes) = await provider.TryWriteBytesAsync(context, array.AsSpan()).ConfigureAwait(false);
 			Assert.IsTrue(provider.MaxBytesInIdentity >= bytes, "Written size bigger then max size");
 			return array;
 		}

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
@@ -140,11 +140,11 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 				IsApplicable = true;
 			}
 
-			public Task<bool> TryWriteBytesAsync(HttpContext context, Span<byte> span, out int bytesWritten)
+			public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span)
 			{
 				Assert.AreEqual(MaxBytesInIdentity, span.Length, "Wrond span size provided");
 				m_calls++;
-				bytesWritten = IsApplicable ? MaxBytesInIdentity : 0;
+				int bytesWritten = IsApplicable ? MaxBytesInIdentity : 0;
 
 				foreach (byte val in span)
 				{
@@ -156,10 +156,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 
 				if (m_provider != null)
 				{
-					return m_provider.TryWriteBytesAsync(context, span, out bytesWritten);
+					return m_provider.TryWriteBytesAsync(context, span);
 				}
 
-				return Task.FromResult(IsApplicable);
+				return Task.FromResult((IsApplicable, bytesWritten));
 			}
 
 			public void AssertCallsAndReset(bool shouldBeCalled)


### PR DESCRIPTION
Because async functions cannot use reference inputs, in this case the out, I have converted it into a return tuple so that it can be used in async functions

Have updated unit tests accordingly