### PR TITLE
Only run gategen target when needed

### DIFF
--- a/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
+++ b/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.targets
@@ -19,7 +19,7 @@
 		<QCustomInput Include="@(CustomTargetInputs)" />
 	</ItemGroup>
 
-	<Target Name="GateGen" BeforeTargets="CoreCompile">
+	<Target Name="GateGen" BeforeTargets="CoreCompile" Condition="'$(UseGate)' == '' OR '$(UseGateGen)' == 'True'">
 		<Message Text="Running GateGen Target" />
 
 		<Error Text="The GatesXml property is not defined." Condition="'$(GatesXml)' == ''" />


### PR DESCRIPTION
Only use the gategen target when we are actually generating gates cs file as otherwise it will throw an error when gates cs file not present in intermediate output path