### PR TITLE
Using memory for async methods

### DIFF
--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IUserIdentityProvider.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		/// <summary>
 		/// Tries to extract user information for HttpContext to create user hash
 		/// </summary>
-		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span);
+		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Memory<byte> memory);
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/IdentityProviders/IpBasedUserIdentityProvider.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	{
 		public int MaxBytesInIdentity { get; } = 16; // IPv6 size, from here https://github.com/dotnet/runtime/blob/26a71f95b708721065f974fd43ba82a1dcb3e8f0/src/libraries/Common/src/System/Net/IPAddressParserStatics.cs#L9
 
-		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span)
+		public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Memory<byte> memory)
 		{
 			int bytesWritten = -1;
 			IHttpConnectionFeature connection = context.Features.Get<IHttpConnectionFeature>();
 			IPAddress? remoteIpAddress = connection.RemoteIpAddress;
 
 			return Task.FromResult((remoteIpAddress != null
-				&& remoteIpAddress.TryWriteBytes(span, out bytesWritten), bytesWritten));
+				&& remoteIpAddress.TryWriteBytes(memory.Span.Slice(0, MaxBytesInIdentity), out bytesWritten), bytesWritten));
 		}
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/EmptySaltProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/EmptySaltProvider.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	{
 		public ReadOnlySpan<byte> GetSalt() => Span<byte>.Empty;
 
+		public int MaxBytesInSalt => 0;
+
 		public void Dispose() { }
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/ISaltProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/ISaltProvider.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	internal interface ISaltProvider : IDisposable
 	{
 		ReadOnlySpan<byte> GetSalt();
+
+		int MaxBytesInSalt { get; }
 	}
 }

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/RotatingSaltProvider.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/RotatingSaltProvider.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			return saltSpan;
 		}
 
+		public int MaxBytesInSalt => SaltLength;
+
 		public void Dispose()
 		{
 			m_currentSaltMemory.Dispose();

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 
 		internal async Task<string> CreateUserHashAsync(HttpContext context)
 		{
-			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent(m_maxIdentitySize + m_saltProvider.GetSalt().Length);
+			int len = m_saltProvider.GetSalt().Length;
+			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent((m_maxIdentitySize + m_saltProvider.GetSalt().Length));
 
 			// Done because span cannot be declared in an async function
 			uidMemoryOwner.Memory.Span.Fill(0);
@@ -57,7 +58,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			foreach (IUserIdentityProvider provider in m_userIdentityProviders)
 			{
 				bool success;
-				(success, identityBytesWritten) = await provider.TryWriteBytesAsync(context, uidMemoryOwner.Memory.Span.Slice(0, provider.MaxBytesInIdentity))
+				(success, identityBytesWritten) = await provider.TryWriteBytesAsync(context, uidMemoryOwner.Memory)
 					.ConfigureAwait(false);
 				if (success)
 				{

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 
 		internal async Task<string> CreateUserHashAsync(HttpContext context)
 		{
-			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent(m_maxIdentitySize + m_salt.Length);
+			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent(m_maxIdentitySize + m_saltProvider.MaxBytesInSalt);
 
 			// Done because span cannot be declared in an async function
 			uidMemoryOwner.Memory.Span.Fill(0);
@@ -69,10 +69,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 				}
 			}
 
-			return GetHashString(m_salt, uidMemoryOwner.Memory.Span, identityBytesWritten);
+			return GetHashString(m_saltProvider.GetSalt(), uidMemoryOwner.Memory.Span, identityBytesWritten);
 		}
-
-		private ReadOnlySpan<byte> m_salt => m_saltProvider.GetSalt();
 
 		/// <summary>
 		/// This method was made because span byte cannot be declared in async or lambda functions

--- a/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/UserIdentity/UserIdentityMiddleware.cs
@@ -48,8 +48,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 
 		internal async Task<string> CreateUserHashAsync(HttpContext context)
 		{
-			int len = m_saltProvider.GetSalt().Length;
-			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent((m_maxIdentitySize + m_saltProvider.GetSalt().Length));
+			using IMemoryOwner<byte> uidMemoryOwner = MemoryPool<byte>.Shared.Rent(m_maxIdentitySize + m_salt.Length);
 
 			// Done because span cannot be declared in an async function
 			uidMemoryOwner.Memory.Span.Fill(0);
@@ -64,10 +63,16 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 				{
 					break;
 				}
+				else
+				{
+					uidMemoryOwner.Memory.Span.Fill(0);
+				}
 			}
 
-			return GetHashString(m_saltProvider.GetSalt(), uidMemoryOwner.Memory.Span, identityBytesWritten);
+			return GetHashString(m_salt, uidMemoryOwner.Memory.Span, identityBytesWritten);
 		}
+
+		private ReadOnlySpan<byte> m_salt => m_saltProvider.GetSalt();
 
 		/// <summary>
 		/// This method was made because span byte cannot be declared in async or lambda functions

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/IpBasedUserIdentityProviderTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 		{
 			IUserIdentityProvider provider = new IpBasedUserIdentityProvider();
 			(HttpContext context, _) = HttpContextHelper.CreateHttpContext();
-
-			(bool result, int bytesWritten) = await provider.TryWriteBytesAsync(context, new byte[provider.MaxBytesInIdentity].AsSpan()).ConfigureAwait(false);
+			Memory<byte> memory = new byte[provider.MaxBytesInIdentity];
+			(bool result, int bytesWritten) = await provider.TryWriteBytesAsync(context, memory).ConfigureAwait(false);
 			Assert.IsFalse(result);
 			Assert.AreEqual(-1, bytesWritten);
 		}
@@ -41,10 +41,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 
 		private async Task<byte[]> GetIdentityAsync(IUserIdentityProvider provider, HttpContext context)
 		{
-			byte[] array = new byte[provider.MaxBytesInIdentity];
-			(bool success, int bytes) = await provider.TryWriteBytesAsync(context, array.AsSpan()).ConfigureAwait(false);
+			Memory<byte> memory = new byte[provider.MaxBytesInIdentity];
+			(_, int bytes) = await provider.TryWriteBytesAsync(context, memory).ConfigureAwait(false);
 			Assert.IsTrue(provider.MaxBytesInIdentity >= bytes, "Written size bigger then max size");
-			return array;
+			return memory.Span.ToArray();
 		}
 	}
 }

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
@@ -179,7 +179,11 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 
 		private class TestSaltProvider : ISaltProvider
 		{
-			public byte[] Salt { get; } = new byte[128];
+			private const int SaltSize = 128;
+
+			public byte[] Salt { get; } = new byte[SaltSize];
+
+			public int MaxBytesInSalt => SaltSize;
 
 			public void Dispose() { }
 			public ReadOnlySpan<byte> GetSalt() => Salt.AsSpan();

--- a/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
+++ b/tests/Extensions/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/UserIdentiyMiddlewareTests.cs
@@ -140,8 +140,9 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 				IsApplicable = true;
 			}
 
-			public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Span<byte> span)
+			public Task<(bool success, int bytesWritten)> TryWriteBytesAsync(HttpContext context, Memory<byte> memory)
 			{
+				Span<byte> span = memory.Span.Slice(0, MaxBytesInIdentity);
 				Assert.AreEqual(MaxBytesInIdentity, span.Length, "Wrond span size provided");
 				m_calls++;
 				int bytesWritten = IsApplicable ? MaxBytesInIdentity : 0;
@@ -156,7 +157,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 
 				if (m_provider != null)
 				{
-					return m_provider.TryWriteBytesAsync(context, span);
+					return m_provider.TryWriteBytesAsync(context, memory);
 				}
 
 				return Task.FromResult((IsApplicable, bytesWritten));


### PR DESCRIPTION
Removing the use of Span in async methods and replacing it with memory which allows for the span to be accessed in async methods. Have updated unit tests accordingly, link to docs about memory and span usage https://docs.microsoft.com/en-us/dotnet/standard/memory-and-spans/memory-t-usage-guidelines