### PR TITLE
Wrappers for late construction

### DIFF
--- a/src/Extensions/Abstractions/Wrappers/IWrapper.cs
+++ b/src/Extensions/Abstractions/Wrappers/IWrapper.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Omex.Extensions.Abstractions.Wrappers
+{
+	/// <summary>
+	/// Generic Wrapper for objects
+	/// </summary>
+	public interface IWrapper<T>
+	{
+		/// <summary>
+		/// Returns stored object from wrapper
+		/// </summary>
+		public T Get();
+	}
+}

--- a/src/Extensions/Abstractions/Wrappers/IWrapper.cs
+++ b/src/Extensions/Abstractions/Wrappers/IWrapper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.Omex.Extensions.Abstractions.Wrappers
 {
 	/// <summary>
@@ -11,6 +13,6 @@ namespace Microsoft.Omex.Extensions.Abstractions.Wrappers
 		/// <summary>
 		/// Returns stored object from wrapper
 		/// </summary>
-		public T Get();
+		public Task<T> GetAsync();
 	}
 }

--- a/src/Extensions/Abstractions/Wrappers/Wrapper.cs
+++ b/src/Extensions/Abstractions/Wrappers/Wrapper.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Omex.Extensions.Abstractions.Wrappers
+{
+	/// <summary>
+	/// Wrapper for late object construction
+	/// </summary>
+	public class Wrapper<T> : IWrapper<T>
+	{
+		private T? m_instance;
+
+		private Func<Task<T>> m_factory;
+
+		/// <summary>
+		/// Constructor with factory responsible for late construction
+		/// </summary>
+		public Wrapper(Func<Task<T>> factory)
+		{
+			m_factory = factory;
+		}
+
+		/// <summary>
+		/// Returns along with constructing instance if not existed before 
+		/// </summary>
+		public T Get()
+		{
+			if (m_instance == null)
+			{
+				m_instance = m_factory.Invoke().Result;
+			}
+
+			return m_instance;
+		}
+	}
+}

--- a/src/Extensions/Abstractions/Wrappers/Wrapper.cs
+++ b/src/Extensions/Abstractions/Wrappers/Wrapper.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Omex.Extensions.Abstractions.Wrappers
 		/// <summary>
 		/// Returns along with constructing instance if not existed before 
 		/// </summary>
-		public T Get()
+		public async Task<T> GetAsync()
 		{
 			if (m_instance == null)
 			{
-				m_instance = m_factory.Invoke().Result;
+				m_instance = await m_factory.Invoke();
 			}
 
 			return m_instance;

--- a/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
+++ b/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		}
 
 		[DataTestMethod]
-		public void Get_ReturnsValidObject()
+		public async Task Get_ReturnsValidObjectAsync()
 		{
 			// Arrange.
 			Wrapper<string> wrapper = new(() => Task.FromResult("42"));
 
 			// Act.
-			string value = wrapper.Get();
+			string value = await wrapper.GetAsync();
 
 			// Assert.
 			NullableAssert.IsNotNull(value);

--- a/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
+++ b/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 	[TestClass]
 	public class WrapperTests
 	{
-		[DataTestMethod]
+		[TestMethod]
 		public void Constructor_InitializesPropertiesProperly()
 		{
 			// Act.
@@ -21,7 +21,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 			// If we are here, PublishAsync didn't explode.
 		}
 
-		[DataTestMethod]
+		[TestMethod]
 		public async Task Get_ReturnsValidObjectAsync()
 		{
 			// Arrange.

--- a/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
+++ b/tests/Extensions/Abstractions.UnitTests/Wrappers/WrapperTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.Omex.Extensions.Abstractions.Wrappers;
+using Microsoft.Omex.Extensions.Testing.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
+{
+	[TestClass]
+	public class WrapperTests
+	{
+		[DataTestMethod]
+		public void Constructor_InitializesPropertiesProperly()
+		{
+			// Act.
+			Wrapper<int> wrapper = new(() => Task.FromResult(42));
+
+			// Assert.
+			// If we are here, PublishAsync didn't explode.
+		}
+
+		[DataTestMethod]
+		public void Get_ReturnsValidObject()
+		{
+			// Arrange.
+			Wrapper<string> wrapper = new(() => Task.FromResult("42"));
+
+			// Act.
+			string value = wrapper.Get();
+
+			// Assert.
+			NullableAssert.IsNotNull(value);
+		}
+	}
+}


### PR DESCRIPTION
# Changes
Introduced `IWrapper` concept and `Wrapper` class for late object construction. Useful when we can't create object in constructor due to deadlock danger.

# Use case

```cs
Wrapper<IServiceFabricClient> m_wrapperExample = new(
				new Func<Task<IServiceFabricClient>>(
					async () => await new ServiceFabricClientBuilder()
					.UseEndpoints(new Uri(options.Value.RestHealthPublisherClusterEndpoint))
					.BuildAsync()
					.ConfigureAwait(false)
				)

// (...)

m_client = await m_wrapperExample .GetAsync();
await m_client.Nodes.ReportNodeHealthAsync(m_nodeName, sfcHealthInfo);
```

# Tests
Covered in `/Wrappers/WrapperTests.cs`