### PR TITLE
Service Fabric Rest Client Factory

### DIFF
--- a/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
+++ b/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions
 		/// Creates service fabric client wrapper instance and returns it
 		/// </summary>
 		/// <param name="options">REST client options</param>
-		/// <returns></returns>
+		/// <returns>Service Fabric Client Wrapper</returns>
 		public static IServiceFabricClientWrapper CreateServiceFabricClientWrapper(IOptions<ServiceFabricRestClientOptions> options)
 		{
 			return new ServiceFabricClientWrapper(options);

--- a/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
+++ b/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions
+{
+	/// <summary>
+	/// Factory for service fabric client wrapper
+	/// </summary>
+	public class ServiceFabricClientFactory
+	{
+		/// <summary>
+		/// Creates service fabric client wrapper instance and returns it
+		/// </summary>
+		/// <param name="options">REST client options</param>
+		/// <returns></returns>
+		public static IServiceFabricClientWrapper CreateServiceFabricClientWrapper(IOptions<ServiceFabricRestClientOptions> options)
+		{
+			return new ServiceFabricClientWrapper(options);
+		}
+	}
+}

--- a/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
+++ b/src/Extensions/ServiceFabricGuest.Abstractions/factory/ServiceFabricClientFactory.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions
 		/// </summary>
 		/// <param name="options">REST client options</param>
 		/// <returns>Service Fabric Client Wrapper</returns>
-		public static IServiceFabricClientWrapper CreateServiceFabricClientWrapper(IOptions<ServiceFabricRestClientOptions> options)
+		public static IServiceFabricClientWrapper Create(ServiceFabricRestClientOptions options)
 		{
-			return new ServiceFabricClientWrapper(options);
+			return new ServiceFabricClientWrapper(Options.Create(options));
 		}
 	}
 }

--- a/tests/Extensions/ServiceFabricGuest.Abstractions.UnitTests/FactoryTests.cs
+++ b/tests/Extensions/ServiceFabricGuest.Abstractions.UnitTests/FactoryTests.cs
@@ -9,17 +9,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests
 {
 	[TestClass]
-	public class FactoryTests
+	public class ServiceFabricClientFactoryTests
 	{
 		[TestMethod]
-		public void Factory_ServiceFabricClientWrapperCreatedProperly()
+		public void ServiceFabricClientFactory_ServiceFabricClientWrapperCreatedProperly()
 		{
 			// Arrange.
 			ServiceFabricRestClientOptions settings = new() { ClusterEndpoint = "fabric://moc" };
-			IOptions<ServiceFabricRestClientOptions> options = Options.Create(settings);
 
 			// Act.
-			IServiceFabricClientWrapper client = ServiceFabricClientFactory.CreateServiceFabricClientWrapper(options);
+			IServiceFabricClientWrapper client = ServiceFabricClientFactory.Create(settings);
 
 			// Assert.
 			Assert.IsNotNull(client);

--- a/tests/Extensions/ServiceFabricGuest.Abstractions.UnitTests/FactoryTests.cs
+++ b/tests/Extensions/ServiceFabricGuest.Abstractions.UnitTests/FactoryTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests
+{
+	[TestClass]
+	public class FactoryTests
+	{
+		[TestMethod]
+		public void Factory_ServiceFabricClientWrapperCreatedProperly()
+		{
+			// Arrange.
+			ServiceFabricRestClientOptions settings = new() { ClusterEndpoint = "fabric://moc" };
+			IOptions<ServiceFabricRestClientOptions> options = Options.Create(settings);
+
+			// Act.
+			IServiceFabricClientWrapper client = ServiceFabricClientFactory.CreateServiceFabricClientWrapper(options);
+
+			// Assert.
+			Assert.IsNotNull(client);
+			Assert.IsInstanceOfType(client, typeof(ServiceFabricClientWrapper));
+		}
+	}
+}


### PR DESCRIPTION
# Description
Minor change which exposes factory which allows us to create instance of `IServiceFabricClientWrapper`. It is especially useful when we want to get client wrapper without DI.

# Tests
Covered via unit testing