### PR TITLE
Changed severity of messages in settings gen

### DIFF
--- a/src/CodeGenerators/SettingsGen/AnalyzerReleases.Unshipped.md
+++ b/src/CodeGenerators/SettingsGen/AnalyzerReleases.Unshipped.md
@@ -4,8 +4,8 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-SETTINGSGEN001 | SettingsGenerator | Warning | BaseGenerator
-SETTINGSGEN002 | SettingsGenerator | Warning | BaseGenerator
-SETTINGSGEN003 | SettingsGenerator | Warning | BaseGenerator
+SETTINGSGEN001 | SettingsGenerator | Info | BaseGenerator
+SETTINGSGEN002 | SettingsGenerator | Info | BaseGenerator
+SETTINGSGEN003 | SettingsGenerator | Info | BaseGenerator
 SETTINGSGEN004 | SettingsGenerator | Error | BaseGenerator
 SETTINGSGEN005 | SettingsGenerator | Error | BaseGenerator

--- a/src/CodeGenerators/SettingsGen/BaseGenerator.cs
+++ b/src/CodeGenerators/SettingsGen/BaseGenerator.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 			title: "Writing to settings file",
 			messageFormat: "Writing to file '{0}'.",
 			category: "SettingsGenerator",
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Info,
 			isEnabledByDefault: true);
 
 		/// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 			title: "Not generating",
 			messageFormat: "Not generating/updating settings file.",
 			category: "SettingsGenerator",
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Info,
 			isEnabledByDefault: true);
 
 		/// <summary>
@@ -121,7 +121,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 			title: "Existing settings match",
 			messageFormat: "No new settings or updated settings so don't need to generate",
 			category: "SettingsGenerator",
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Info,
 			isEnabledByDefault: true);
 
 		/// <summary>


### PR DESCRIPTION
Changed severity of messages in settings gen, to ensure information messages are not causing build failures