### PR TITLE
Using the cloned httprequest message in HttpEndpointHealthcheck

### DIFF
--- a/src/Extensions/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 						? scheme
 						: throw new ArgumentException("Invalid uri scheme", nameof(scheme));
 
-			if(!Uri.TryCreate(relativePath, UriKind.Relative, out Uri? result) || result.IsAbsoluteUri)
+			if (!Uri.TryCreate(relativePath, UriKind.Relative, out Uri? result) || result.IsAbsoluteUri)
 			{
 				throw new ArgumentException("relativePath is not valid or can't be an Absolute uri", nameof(relativePath));
 			}
@@ -58,13 +58,13 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 			{
 				uriBuilder.Path = relativePath;
 				uriBuilder.Scheme = scheme;
-				HttpRequestMessage requestMessage = new (method ?? HttpMethod.Get, uriBuilder.Uri);
+				HttpRequestMessage requestMessage = new(method ?? HttpMethod.Get, uriBuilder.Uri);
 
 				if (headers != null)
 				{
 					foreach (KeyValuePair<string, IEnumerable<string>> pair in headers)
 					{
-						if(!requestMessage.Headers.TryAddWithoutValidation(pair.Key, pair.Value))
+						if (!requestMessage.Headers.TryAddWithoutValidation(pair.Key, pair.Value))
 						{
 							string errorMessage = string.Format(
 								CultureInfo.InvariantCulture,
@@ -104,7 +104,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 			params KeyValuePair<string, object>[] reportData)
 		{
 			int port = SfConfigurationProvider.GetEndpointPort(endpointName);
-			UriBuilder uriBuilder = new UriBuilder(Uri.UriSchemeHttp, "localhost", port);
+			UriBuilder uriBuilder = new(Uri.UriSchemeHttp, "localhost", port);
 			HttpRequestMessage requestMessage = httpRequestMessageBuilder(uriBuilder);
 
 			return builder.AddTypeActivatedCheck<HttpEndpointHealthCheck>(

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -85,9 +85,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 #if !NETCOREAPP3_1 && !NETSTANDARD2_0
 			clone.VersionPolicy =  message.VersionPolicy;
 
-			foreach (KeyValuePair<string, object?> item in message.Options)
+			foreach (KeyValuePair<string, object?> option in message.Options)
 			{
-				clone.Options.Set(new HttpRequestOptionsKey<object?>(item.Key), item.Value);
+				clone.Options.Set(new HttpRequestOptionsKey<object?>(option.Key), option.Value);
+			}
+#else
+			foreach (KeyValuePair<string, object> prop in message.Properties)
+			{
+				clone.Properties.Add(prop.Key, prop.Value);
 			}
 #endif
 

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -82,6 +82,15 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
 			}
 
+#if !NETCOREAPP3_1 && !NETSTANDARD2_0
+			clone.VersionPolicy =  message.VersionPolicy;
+
+			foreach (KeyValuePair<string, object?> item in message.Options)
+			{
+				clone.Options.Set<object?>(new HttpRequestOptionsKey<object?>(item.Key), item.Value);
+			}
+#endif
+
 			return clone;
 		}
 	}

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			foreach (KeyValuePair<string, object?> item in message.Options)
 			{
-				clone.Options.Set<object?>(new HttpRequestOptionsKey<object?>(item.Key), item.Value);
+				clone.Options.Set(new HttpRequestOptionsKey<object?>(item.Key), item.Value);
 			}
 #endif
 


### PR DESCRIPTION
HttpEndpointHealthcheck will clone the configured HttpRequestMessage from the parameters before sending the request due to the restriction of the same http request message not being allowed to send more then once. 