### PR TITLE
Clean HealthPublisher base from SF dependency

### DIFF
--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
@@ -3,19 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Fabric;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.ObjectPool;
-using ServiceFabricHealth = System.Fabric.Health;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
-	/// <summary>
-	/// Base health check class
-	/// </summary>
 	internal abstract class HealthCheckPublisher : IHealthCheckPublisher
 	{
 		internal readonly ObjectPool<StringBuilder> StringBuilderPool;

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
 	internal abstract class HealthCheckPublisher : IHealthCheckPublisher
 	{
-		internal readonly ObjectPool<StringBuilder> StringBuilderPool;
+		protected readonly ObjectPool<StringBuilder> StringBuilderPool;
 
 		internal abstract string HealthReportSourceId { get; }
 
@@ -21,20 +21,19 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		public HealthCheckPublisher(ObjectPoolProvider objectPoolProvider) => StringBuilderPool = objectPoolProvider.CreateStringBuilderPool();
 
-		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
+		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken); 
 
-		protected void PublishAllEntries(HealthReport report, Func<string, HealthStatus, string, Task> publishFunc,
-			 CancellationToken cancellationToken)
+		protected void PublishAllEntries(HealthReport report, CancellationToken cancellationToken)
 		{
 			// We trust the framework to ensure that the report is not null and doesn't contain null entries.
 			foreach (KeyValuePair<string, HealthReportEntry> entryPair in report.Entries)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				publishFunc(entryPair.Key, entryPair.Value.Status, BuildSfHealthInformationDescription(entryPair.Value));
+				PublishHealthReportEntry(entryPair.Key, entryPair.Value.Status, BuildSfHealthInformationDescription(entryPair.Value));
 			}
 
 			cancellationToken.ThrowIfCancellationRequested();
-			publishFunc(HealthReportSummaryProperty, report.Status, BuildSfHealthInformationDescription(report));
+			PublishHealthReportEntry(HealthReportSummaryProperty, report.Status, BuildSfHealthInformationDescription(report));
 		}
 
 		protected string BuildSfHealthInformationDescription(HealthReport report)
@@ -109,5 +108,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			return description;
 		}
+
+		protected abstract void PublishHealthReportEntry(string healthCheckName, HealthStatus status, string description);
 	}
 }

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		public HealthCheckPublisher(ObjectPoolProvider objectPoolProvider) => StringBuilderPool = objectPoolProvider.CreateStringBuilderPool();
 
-		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken); 
+		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
 
 		protected void PublishAllEntries(HealthReport report, CancellationToken cancellationToken)
 		{

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
@@ -23,18 +23,18 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
 
-		protected void PublishAllEntries(HealthReport report, Func<HealthStatus, string, Task> publishFunc,
+		protected void PublishAllEntries(HealthReport report, Func<string, HealthStatus, string, Task> publishFunc,
 			 CancellationToken cancellationToken)
 		{
 			// We trust the framework to ensure that the report is not null and doesn't contain null entries.
 			foreach (KeyValuePair<string, HealthReportEntry> entryPair in report.Entries)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				publishFunc(entryPair.Value.Status, BuildSfHealthInformationDescription(entryPair.Value));
+				publishFunc(entryPair.Key, entryPair.Value.Status, BuildSfHealthInformationDescription(entryPair.Value));
 			}
 
 			cancellationToken.ThrowIfCancellationRequested();
-			publishFunc(report.Status, BuildSfHealthInformationDescription(report));
+			publishFunc(HealthReportSummaryProperty, report.Status, BuildSfHealthInformationDescription(report));
 		}
 
 		protected string BuildSfHealthInformationDescription(HealthReport report)

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/HealthCheckPublisher.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		public abstract Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
 
-		protected void PublishAllEntries(HealthReport report, Action<HealthStatus, string> publishFunc,
+		protected void PublishAllEntries(HealthReport report, Func<HealthStatus, string, Task> publishFunc,
 			 CancellationToken cancellationToken)
 		{
 			// We trust the framework to ensure that the report is not null and doesn't contain null entries.

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
@@ -7,12 +7,10 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
-using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Abstractions;
 using Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions;
 using Microsoft.ServiceFabric.Client;
 using ServiceFabricCommon = Microsoft.ServiceFabric.Common;
-using ServiceFabricHealth = System.Fabric.Health;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
@@ -58,10 +58,11 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			m_client = await m_clientWrapper.GetAsync();
 
-			Action<HealthStatus, string> reportHealthWithConvert = new(async (status, description) =>
+			Func<HealthStatus, string, Task> reportHealthWithConvert = new((status, description) =>
 			{
 				ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfcHealthState(status), description: description);
-				await PublishHealthInfoAsync(healthEntry);
+				PublishHealthInfoAsync(healthEntry).GetAwaiter().GetResult();
+				return Task.CompletedTask;
 			});
 
 			PublishAllEntries(report, reportHealthWithConvert, cancellationToken);

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			Action<HealthStatus, string> reportHealthWithConvert = new(async (status, description) =>
 			{
-				await PublishHealthInfoAsync(new ServiceFabricCommon.HealthInformation(HealthReportSourceId, description, ToSfcHealthState(status)));
+				ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfcHealthState(status), description: description);
+				await PublishHealthInfoAsync(healthEntry);
 			});
 
 			PublishAllEntries(report, reportHealthWithConvert, cancellationToken);

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			m_client = await m_clientWrapper.GetAsync();
 
-			Func<HealthStatus, string, Task> reportHealthWithConvert = new((status, description) =>
+			Func<string, HealthStatus, string, Task> reportHealthWithConvert = new((healthCheckName, status, description) =>
 			{
-				ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfcHealthState(status), description: description);
+				ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, healthCheckName, ToSfcHealthState(status), description: description);
 				PublishHealthInfoAsync(healthEntry).GetAwaiter().GetResult();
 				return Task.CompletedTask;
 			});

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthCheckPublisher.cs
@@ -58,15 +58,15 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			m_client = await m_clientWrapper.GetAsync();
 
-			Func<string, HealthStatus, string, Task> reportHealthWithConvert = new((healthCheckName, status, description) =>
-			{
-				ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, healthCheckName, ToSfcHealthState(status), description: description);
-				PublishHealthInfoAsync(healthEntry).GetAwaiter().GetResult();
-				return Task.CompletedTask;
-			});
-
-			PublishAllEntries(report, reportHealthWithConvert, cancellationToken);
+			PublishAllEntries(report, cancellationToken);
 		}
+
+		protected override void PublishHealthReportEntry(string healthCheckName, HealthStatus status, string description)
+		{
+			ServiceFabricCommon.HealthInformation healthEntry = new(HealthReportSourceId, healthCheckName, ToSfcHealthState(status), description: description);
+			PublishHealthInfoAsync(healthEntry).GetAwaiter().GetResult();
+		}
+
 
 		private ServiceFabricCommon.HealthState ToSfcHealthState(HealthStatus healthStatus) =>
 			healthStatus switch

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Omex.Extensions.Abstractions;
-using SfHealthInformation = System.Fabric.Health.HealthInformation;
+using ServiceFabricHealth = System.Fabric.Health;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
@@ -18,7 +18,6 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		private readonly IAccessor<IServicePartition> m_partitionAccessor;
 
 		private readonly ILogger<ServiceFabricHealthCheckPublisher> m_logger;
-
 		internal override string HealthReportSourceId => nameof(ServiceFabricHealthCheckPublisher);
 
 		public ServiceFabricHealthCheckPublisher(
@@ -41,16 +40,37 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 			}
 
 			// Avoiding repeated pattern matching for each report entry.
-			Action<SfHealthInformation> reportHealth = partition switch
+			Action<ServiceFabricHealth.HealthInformation> reportHealth = partition switch
 			{
 				IStatefulServicePartition statefulPartition => statefulPartition.ReportReplicaHealth,
 				IStatelessServicePartition statelessPartition => statelessPartition.ReportInstanceHealth,
 				_ => throw new ArgumentException($"Service partition type '{partition.GetType()}' is not supported."),
 			};
 
-			PublishAllEntries(report, reportHealth, cancellationToken);
+			Action<HealthStatus, string> reportHealthWithConvert = new((status, description) =>
+			{
+				reportHealth(new ServiceFabricHealth.HealthInformation(HealthReportSourceId, description, ToSfHealthState(status)));
+			});
+
+			try
+			{
+				PublishAllEntries(report, reportHealthWithConvert, cancellationToken);
+			}
+			catch (FabricObjectClosedException)
+			{
+				// Ignore, the service instance is closing.
+			}
 
 			return Task.CompletedTask;
 		}
+
+		private ServiceFabricHealth.HealthState ToSfHealthState(HealthStatus healthStatus) =>
+			healthStatus switch
+			{
+				HealthStatus.Healthy => ServiceFabricHealth.HealthState.Ok,
+				HealthStatus.Degraded => ServiceFabricHealth.HealthState.Warning,
+				HealthStatus.Unhealthy => ServiceFabricHealth.HealthState.Error,
+				_ => throw new ArgumentException($"'{healthStatus}' is not a valid health status."),
+			};
 	}
 }

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				_ => throw new ArgumentException($"Service partition type '{partition.GetType()}' is not supported."),
 			};
 
-			Func<HealthStatus, string, Task> reportHealthWithConvert = new((status, description) =>
+			Func<string, HealthStatus, string, Task> reportHealthWithConvert = new((healthCheckName, status, description) =>
 			{
-				ServiceFabricHealth.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfHealthState(status));
+				ServiceFabricHealth.HealthInformation healthEntry = new(HealthReportSourceId, healthCheckName, ToSfHealthState(status));
 				healthEntry.Description = description;
 				reportHealth(healthEntry);
 				return Task.CompletedTask;

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		protected override void PublishHealthReportEntry(string healthCheckName, HealthStatus status, string description)
 		{
-			if(m_reportHealth == null)
+			if (m_reportHealth == null)
 			{
 				m_logger.LogWarning(Tag.Create(), "Publisher run before health report functions is provided.");
 				return;
@@ -74,7 +74,6 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 			healthEntry.Description = description;
 			m_reportHealth(healthEntry);
 		}
-
 
 		private ServiceFabricHealth.HealthState ToSfHealthState(HealthStatus healthStatus) =>
 			healthStatus switch

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		private readonly IAccessor<IServicePartition> m_partitionAccessor;
 
 		private readonly ILogger<ServiceFabricHealthCheckPublisher> m_logger;
+
 		internal override string HealthReportSourceId => nameof(ServiceFabricHealthCheckPublisher);
 
 		public ServiceFabricHealthCheckPublisher(
@@ -49,7 +50,9 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			Action<HealthStatus, string> reportHealthWithConvert = new((status, description) =>
 			{
-				reportHealth(new ServiceFabricHealth.HealthInformation(HealthReportSourceId, description, ToSfHealthState(status)));
+				ServiceFabricHealth.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfHealthState(status));
+				healthEntry.Description = description;
+				reportHealth(healthEntry);
 			});
 
 			try

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceFabricHealthCheckPublisher.cs
@@ -48,11 +48,12 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				_ => throw new ArgumentException($"Service partition type '{partition.GetType()}' is not supported."),
 			};
 
-			Action<HealthStatus, string> reportHealthWithConvert = new((status, description) =>
+			Func<HealthStatus, string, Task> reportHealthWithConvert = new((status, description) =>
 			{
 				ServiceFabricHealth.HealthInformation healthEntry = new(HealthReportSourceId, HealthReportSummaryProperty, ToSfHealthState(status));
 				healthEntry.Description = description;
 				reportHealth(healthEntry);
+				return Task.CompletedTask;
 			});
 
 			try


### PR DESCRIPTION
## Description
Changed little implementation of HealthCheckPublisher base in order to avoid SF dependency in Health check publisher base

## Tests
Unit tests pass, no need for new ones. Tested on sample service.