### PR TITLE
Specify updated version of System.Text.Encodings.Web explicitly

### DIFF
--- a/tests/Extensions/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
+++ b/tests/Extensions/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Extensions\Compatibility.UlsLoggerAdapter\Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.csproj" />

--- a/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
+++ b/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(IsNetCore)">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(Microsoft_AspNetCore_Http_Abstractions_Version)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="DefaultGates.xml" Link="DefaultGates.xml">


### PR DESCRIPTION
Defaults are sometimes getting used, this sets these projects to use the latest version of System.Text.Encodings.Web explicitly.