### PR TITLE
Added ProductVersion constructor with nullable inputs

### DIFF
--- a/src/System/Model/Types/ProductVersion.cs
+++ b/src/System/Model/Types/ProductVersion.cs
@@ -110,6 +110,27 @@ namespace Microsoft.Omex.System.Model.Types
 		}
 
 		/// <summary>
+		/// Initializes a new instance of the ProductVersion class using the specified
+		/// major, minor, build and revision values.
+		/// </summary>
+		/// <param name="major">The major version number.</param>
+		/// <param name="minor">The minor version number.</param>
+		/// <param name="build">The build number (nullable)</param>
+		/// <param name="revision">The revision number (nullable)</param>
+		public ProductVersion(int major, int minor, int? build, int? revision)
+		{
+			Code.Expects<ArgumentOutOfRangeException>(major >= 0, "Major is less than zero.", TaggingUtilities.ReserveTag(0));
+			Code.Expects<ArgumentOutOfRangeException>(minor >= 0, "Minor is less than zero.", TaggingUtilities.ReserveTag(0));
+			Code.Expects<ArgumentOutOfRangeException>(build == null || build >= 0, "Build is not null and is less than zero.", TaggingUtilities.ReserveTag(0));
+			Code.Expects<ArgumentOutOfRangeException>(revision == null || revision >= 0, "Revision is not null and is less than zero.", TaggingUtilities.ReserveTag(0));
+
+			Major = major;
+			Minor = minor;
+			Build = build;
+			Revision = revision;
+		}
+
+		/// <summary>
 		/// Determines whether two specified objects are not equal.
 		/// </summary>
 		/// <param name="v1">The first object.</param>

--- a/src/System/Model/Types/ProductVersion.cs
+++ b/src/System/Model/Types/ProductVersion.cs
@@ -94,35 +94,14 @@ namespace Microsoft.Omex.System.Model.Types
 		/// </summary>
 		/// <param name="major">The major version number.</param>
 		/// <param name="minor">The minor version number.</param>
-		/// <param name="build">The build number</param>
-		/// <param name="revision">The revision number</param>
-		public ProductVersion(int major, int minor, int build, int revision)
-		{
-			Code.Expects<ArgumentOutOfRangeException>(major >= 0, "Major is less than zero.", TaggingUtilities.ReserveTag(0x23820859 /* tag_9667z */));
-			Code.Expects<ArgumentOutOfRangeException>(minor >= 0, "Minor is less than zero.", TaggingUtilities.ReserveTag(0x23820880 /* tag_9668a */));
-			Code.Expects<ArgumentOutOfRangeException>(build >= 0, "Build is less than zero.", TaggingUtilities.ReserveTag(0x23820881 /* tag_9668b */));
-			Code.Expects<ArgumentOutOfRangeException>(revision >= 0, "Revision is less than zero.", TaggingUtilities.ReserveTag(0x23820882 /* tag_9668c */));
-
-			Major = major;
-			Minor = minor;
-			Build = build;
-			Revision = revision;
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the ProductVersion class using the specified
-		/// major, minor, build and revision values.
-		/// </summary>
-		/// <param name="major">The major version number.</param>
-		/// <param name="minor">The minor version number.</param>
 		/// <param name="build">The build number (nullable)</param>
 		/// <param name="revision">The revision number (nullable)</param>
 		public ProductVersion(int major, int minor, int? build, int? revision)
 		{
-			Code.Expects<ArgumentOutOfRangeException>(major >= 0, "Major is less than zero.", TaggingUtilities.ReserveTag(0));
-			Code.Expects<ArgumentOutOfRangeException>(minor >= 0, "Minor is less than zero.", TaggingUtilities.ReserveTag(0));
-			Code.Expects<ArgumentOutOfRangeException>(build == null || build >= 0, "Build is not null and is less than zero.", TaggingUtilities.ReserveTag(0));
-			Code.Expects<ArgumentOutOfRangeException>(revision == null || revision >= 0, "Revision is not null and is less than zero.", TaggingUtilities.ReserveTag(0));
+			Code.Expects<ArgumentOutOfRangeException>(major >= 0, "Major is less than zero.", TaggingUtilities.ReserveTag(0x23820859 /* tag_9667z */));
+			Code.Expects<ArgumentOutOfRangeException>(minor >= 0, "Minor is less than zero.", TaggingUtilities.ReserveTag(0x23820880 /* tag_9668a */));
+			Code.Expects<ArgumentOutOfRangeException>(build == null || build >= 0, "Build is not null and is less than zero.", TaggingUtilities.ReserveTag(0x23820881 /* tag_9668b */));
+			Code.Expects<ArgumentOutOfRangeException>(revision == null || revision >= 0, "Revision is not null and is less than zero.", TaggingUtilities.ReserveTag(0x23820882 /* tag_9668c */));
 
 			Major = major;
 			Minor = minor;


### PR DESCRIPTION
In order to make type casting easier and uniform across internal repos of Omex