### PR TITLE
Add Error for project that depend on Microsoft.Omex.System

### DIFF
--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -1,0 +1,13 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Enforce nullability check and language version -->
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <Target Name="RunValidations" AfterTargets="Build">
+    <Error
+        Condition="'$(UseUnsupportedOmexPackage)' != 'true'"
+        Code="OMEX0101"
+        HelpKeyword="DoNotUseUnsupportedPackages"
+        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages dependend on them would be out of support after 30 of September 2021. You can temporary use flag &lt;UseUnsupportedOmexPackage&gt;true&lt;/UseUnsupportedOmexPackage&gt;, but add comment with PBI to fix it." />
+</Project>

--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="RunValidations" AfterTargets="Build">
+  <Target Name="DisplayWarnings" AfterTargets="Build">
     <Warning
         Condition="'$(UseUnsupportedOmexSystemPackage)' != 'true'"
         Code="OMEX0101"

--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -4,5 +4,5 @@
         Condition="'$(UseUnsupportedOmexSystemPackage)' != 'true'"
         Code="OMEX0101"
         HelpKeyword="DoNotUseUnsupportedPackages"
-        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of September 2021. You can temporarily use flag &lt;UseUnsupportedOmexSystemPackage&gt;true&lt;/UseUnsupportedOmexSystemPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
+        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of November 2021. You can temporarily use flag &lt;UseUnsupportedOmexSystemPackage&gt;true&lt;/UseUnsupportedOmexSystemPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
 </Project>

--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -1,8 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="DisplayWarnings" AfterTargets="Build">
-    <Warning
-        Condition="'$(UseUnsupportedOmexSystemPackage)' != 'true'"
-        Code="OMEX0101"
-        HelpKeyword="DoNotUseUnsupportedPackages"
-        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of November 2021. You can temporarily use flag &lt;UseUnsupportedOmexSystemPackage&gt;true&lt;/UseUnsupportedOmexSystemPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
-</Project>

--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -1,13 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <!-- Enforce nullability check and language version -->
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
   <Target Name="RunValidations" AfterTargets="Build">
-    <Error
-        Condition="'$(UseUnsupportedOmexPackage)' != 'true'"
+    <Warning
+        Condition="'$(UseUnsupportedOmexSystemPackage)' != 'true'"
         Code="OMEX0101"
         HelpKeyword="DoNotUseUnsupportedPackages"
-        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of September 2021. You can temporarily use flag &lt;UseUnsupportedOmexPackage&gt;true&lt;/UseUnsupportedOmexPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
+        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of September 2021. You can temporarily use flag &lt;UseUnsupportedOmexSystemPackage&gt;true&lt;/UseUnsupportedOmexSystemPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
 </Project>

--- a/src/System/BuildTransitive/Microsoft.Omex.System.props
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.props
@@ -9,5 +9,5 @@
         Condition="'$(UseUnsupportedOmexPackage)' != 'true'"
         Code="OMEX0101"
         HelpKeyword="DoNotUseUnsupportedPackages"
-        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages dependend on them would be out of support after 30 of September 2021. You can temporary use flag &lt;UseUnsupportedOmexPackage&gt;true&lt;/UseUnsupportedOmexPackage&gt;, but add comment with PBI to fix it." />
+        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of September 2021. You can temporarily use flag &lt;UseUnsupportedOmexPackage&gt;true&lt;/UseUnsupportedOmexPackage&gt; to suppress, but add a reference to the follow work item to fix it." />
 </Project>

--- a/src/System/BuildTransitive/Microsoft.Omex.System.targets
+++ b/src/System/BuildTransitive/Microsoft.Omex.System.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="DisplayWarnings" AfterTargets="Build">
+    <Warning
+        Condition="'$(UseUnsupportedOmexSystemPackage)' != 'true'"
+        Code="OMEX0101"
+        HelpKeyword="DoNotUseUnsupportedPackages"
+        Text="Mirosoft.Omex.System, Microsoft.OMEX.ServiceFabric.Core and packages depending on them will be out of support after the 30th of November 2021. You can temporarily use flag &lt;UseUnsupportedOmexSystemPackage&gt;true&lt;/UseUnsupportedOmexSystemPackage&gt; to suppress error, but add a comment with ID of work item to remove reference." />
+</Project>

--- a/src/System/Microsoft.Omex.System.csproj
+++ b/src/System/Microsoft.Omex.System.csproj
@@ -11,4 +11,7 @@
     <PackageProjectUrl>https://github.com/microsoft/Omex/tree/master/src/System</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;System</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <Content Include="BuildTransitive\*" Pack="true" PackagePath="buildTransitive" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds a build error for projects that reference `Microsoft.Omex.System` or packages that depend on it.

Idea is that projects that reference them would need to add special flag `<UseUnsupportedOmexSystemPackage>true</UseUnsupportedOmexSystemPackage>` with a comment to PBI about fixing it and plan for removing a dependency. 

Initial PR would create warning instead of error and we would switch after all consumers updated