### PR TITLE
Removed the obsolete attribute from the certificate reader get by thumbprint method

### DIFF
--- a/src/Extensions/Hosting/Certificates/ICertificateReader.cs
+++ b/src/Extensions/Hosting/Certificates/ICertificateReader.cs
@@ -40,8 +40,9 @@ namespace Microsoft.Omex.Extensions.Hosting.Certificates
 		/// <param name="thumbprint">Thumbprint of certificate</param>
 		/// <param name="refreshCache">Refresh cache before looking for certificate</param>
 		/// <param name="storeName">Certificate store</param>
-		/// <remarks>It preferable to getting certificate by common name</remarks>
-		[Obsolete("Consider getting certificate by common name instead thumbprint", false)]
+		/// <remarks>It preferable to getting certificate by common name.
+		/// Please use this method only in cases where retrieving by common name might not work, e.g. a certificate used to decrypt an access token.
+		/// </remarks>
 		X509Certificate2? GetCertificateByThumbprint(string thumbprint, bool refreshCache = false, StoreName storeName = StoreName.My);
 	}
 }


### PR DESCRIPTION
There are some use cases where a certificate has to be retrieved by thumbprint. An example is a certificate used for decrypting access tokens. To enable certificate rotation there, we could have multiple certificates with the same common name installed on the machine, but would like to use a particular one selected by thumbprint.