### PR TITLE
Disabling automatic restore in NuGet config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="dependencyVersion" value="Highest"  />
+    <add key="dependencyVersion" value="Highest" />
   </config>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3"/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <packageRestore>
     <add key="enabled" value="false" />


### PR DESCRIPTION
For some reason it causes problems when building from VS, disabling it for now, until we've found a better solution.