### PR TITLE
Moved accessor value assignments

### DIFF
--- a/src/Extensions/Hosting.Services/OmexStatelessService.cs
+++ b/src/Extensions/Hosting.Services/OmexStatelessService.cs
@@ -27,6 +27,14 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			m_serviceRegistrator = serviceRegistrator;
 		}
 
+
+		/// <inheritdoc />
+		protected override Task OnOpenAsync(CancellationToken cancellationToken)
+		{
+			m_serviceRegistrator.PartitionAccessor.SetValue(Partition);
+			return base.OnOpenAsync(cancellationToken);
+		}
+
 		/// <inheritdoc />
 		protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners() =>
 			m_serviceRegistrator.ListenerBuilders.Select(b => new ServiceInstanceListener(c => b.Build(this), b.Name));
@@ -34,8 +42,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 		/// <inheritdoc />
 		protected override Task RunAsync(CancellationToken cancellationToken)
 		{
-			m_serviceRegistrator.PartitionAccessor.SetValue(Partition);
-
 			return Task.WhenAll(m_serviceRegistrator.ServiceActions.Select(r => r.RunAsync(this, cancellationToken)));
 		}
 	}

--- a/src/Extensions/Hosting.Services/OmexStatelessService.cs
+++ b/src/Extensions/Hosting.Services/OmexStatelessService.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			m_serviceRegistrator = serviceRegistrator;
 		}
 
-
 		/// <inheritdoc />
 		protected override Task OnOpenAsync(CancellationToken cancellationToken)
 		{

--- a/src/Extensions/Hosting.Services/OmexStatelessService.cs
+++ b/src/Extensions/Hosting.Services/OmexStatelessService.cs
@@ -40,9 +40,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 			m_serviceRegistrator.ListenerBuilders.Select(b => new ServiceInstanceListener(c => b.Build(this), b.Name));
 
 		/// <inheritdoc />
-		protected override Task RunAsync(CancellationToken cancellationToken)
-		{
-			return Task.WhenAll(m_serviceRegistrator.ServiceActions.Select(r => r.RunAsync(this, cancellationToken)));
-		}
+		protected override Task RunAsync(CancellationToken cancellationToken) =>
+			Task.WhenAll(m_serviceRegistrator.ServiceActions.Select(r => r.RunAsync(this, cancellationToken)));
 	}
 }


### PR DESCRIPTION
Context (and StateManager for stateful service) are already available in constructor. Partition is available in OnOpenAsync which is always called when the service is being stood up. RunAsync is not called for secondary stateful replicas.

For more info https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-lifecycle.