### PR TITLE
Improve environment detection in BaseExecutionContext

### DIFF
--- a/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 		// We define them
 		internal const string ClusterNameVariableName = "CLUSTER_NAME";
 		internal const string SliceNameVariableName = "SLICE_NAME";
-		internal const string EnviromentVariableName = "DOTNET_ENVIRONMENT"; // getting environment directly only if we don't have IHostEnvironment ex. InitializationLogger
+		internal const string AspNetCoreEnviromentVariableName = "ASPNETCORE_ENVIRONMENT";
+		internal const string DotNetEnviromentVariableName = "DOTNET_ENVIRONMENT"; // getting environment directly only if we don't have IHostEnvironment ex. InitializationLogger
 
 		// defined by Service Fabric https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-environment-variables-reference
 		internal const string ServiceNameVariableName = "Fabric_ServiceName";
@@ -50,7 +51,10 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 			}
 			else
 			{
-				EnvironmentName = GetVariable(EnviromentVariableName) ?? DefaultEmptyValue;
+				EnvironmentName = GetVariable(EnviromentVariableName) 
+					?? GetVariable(AspNetCoreEnviromentVariableName)
+					?? GetVariable(DotNetEnviromentVariableName)
+					?? Environments.Development;
 				IsPrivateDeployment = string.Equals(EnvironmentName, Environments.Development, StringComparison.OrdinalIgnoreCase);
 			}
 

--- a/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 			}
 			else
 			{
-				EnvironmentName = GetVariable(EnviromentVariableName) 
-					?? GetVariable(AspNetCoreEnviromentVariableName)
+				EnvironmentName = GetVariable(AspNetCoreEnviromentVariableName)
 					?? GetVariable(DotNetEnviromentVariableName)
 					?? Environments.Development;
 				IsPrivateDeployment = string.Equals(EnvironmentName, Environments.Development, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Improve use case when `BaseExecutionContext` created without the generic host, now we can detect bot asp .net core and dotnet env variables and use Development as default