### PR TITLE
Improve Tag.Create logging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,5 +73,7 @@
     <!-- Optional: Include the PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SourceRootLocation>$(MSBuildThisFileDirectory)</SourceRootLocation>
+    <!-- Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive -->
+    <PathMap>$(MSBuildThisFileDirectory)=/</PathMap>
   </PropertyGroup>
 </Project>

--- a/tests/Extensions/Abstractions.UnitTests/TagTests.cs
+++ b/tests/Extensions/Abstractions.UnitTests/TagTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Omex.Extensions.Abstractions.UnitTests
 			Assert.AreEqual(tag1.Name, tag2.Name, "EventId Name should be the same in the same file");
 
 			
-			string relativePath = Path.Combine("tests", "Extensions", "Abstractions.UnitTests", nameof(TagTests) + ".cs"); //This value should be change in case of changing file path or name
-			StringAssert.EndsWith(tag1.Name, relativePath, "tag1 Name should point to current file");
-			StringAssert.EndsWith(tag2.Name, relativePath, "tag2 Name should point to current file");
+			string relativePath = "/tests/Extensions/Abstractions.UnitTests/" + nameof(TagTests) + ".cs"; //This value should be change in case of changing file path or name
+			Assert.AreEqual(tag1.Name, relativePath, "tag1 Name should point to current file");
+			Assert.AreEqual(tag2.Name, relativePath, "tag2 Name should point to current file");
 		}
 
 		[DataTestMethod]


### PR DESCRIPTION
This will change out tags info from 
`D:\a\1\s\src\Extensions\Diagnostics.HealthChecks\AbstractHealthCheck.cs`
to 
`src/Extensions/Diagnostics.HealthChecks/AbstractHealthCheck.cs`
to unify tags
Not sure why slash direction changes, but it's good because now it's the same for Windows and Linux