### PR TITLE
Remove netcoreapp3.1 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="$(MSBuildThisFileDirectory)\Dependencies.props" />
   <PropertyGroup Label="Target Platforms" >
-    <NetCoreVersions>netcoreapp3.1;net5.0</NetCoreVersions>
+    <NetCoreVersions>net5.0</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>
     <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>

--- a/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.csproj
+++ b/src/CodeGenerators/GateGen/Microsoft.Omex.CodeGenerators.GateGen.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>Contains Omex Gating generator code</Description>
     <RootNamespace>Microsoft.Omex.CodeGenerators.GateGen</RootNamespace>
     <AssemblyName>Microsoft.Omex.CodeGenerators.GateGen</AssemblyName>

--- a/src/CodeGenerators/SettingsGen.Example/Settings.xml
+++ b/src/CodeGenerators/SettingsGen.Example/Settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Settings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Section Name="NewSection">
     <Parameter Name="Whatever" Value="" />
     <Parameter Name="TestingThis" Value="Hmmmm" />

--- a/src/Gating.Example/Microsoft.Omex.Gating.Example.csproj
+++ b/src/Gating.Example/Microsoft.Omex.Gating.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
We will still support `netstandard2.0` so it won't break anybody, but we should reduce the number of platforms we support, no good reasons running on `netcoreapp3.1` instead of `net5.0` or `net6.0` by now.