### PR TITLE
Force W3C activity format

### DIFF
--- a/src/Extensions/Activities/ServiceCollectionExtensions.cs
+++ b/src/Extensions/Activities/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
 		public static IServiceCollection AddOmexActivitySource(this IServiceCollection serviceCollection)
 		{
 			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+			Activity.ForceDefaultIdFormat = true;
 			serviceCollection.AddHostedService<ActivityListenerInitializerService>();
 			serviceCollection.AddHostedService<DiagnosticsObserversInitializer>();
 


### PR DESCRIPTION
we are relying on the new W3C Activity.Id format so should use it even if caller sends hierarchical id.