### PR TITLE
Replace consts with static readonly

### DIFF
--- a/src/CodeGenerators/SettingsGen.Example/Settings.xml
+++ b/src/CodeGenerators/SettingsGen.Example/Settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<Settings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Section Name="NewSection">
     <Parameter Name="Whatever" Value="" />
     <Parameter Name="TestingThis" Value="Hmmmm" />

--- a/src/Extensions/Abstractions/Activities/ActivityExtensions.cs
+++ b/src/Extensions/Abstractions/Activities/ActivityExtensions.cs
@@ -20,21 +20,21 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		public static Guid? GetRootIdAsGuid(this Activity activity) =>
 			Guid.TryParse(activity.RootId, out Guid result)
 				? result
-				: (Guid?)null;
+				: null;
 
 		/// <summary>
 		/// Get user hash from activity
 		/// </summary>
 		public static string GetUserHash(this Activity activity) =>
-			activity.GetBaggageItem(UserHashKey) ?? string.Empty;
+			activity.GetBaggageItem(s_userHashKey) ?? string.Empty;
 
 		/// <summary>
 		/// Returns true if activity is transaction
 		/// </summary>
 		public static bool IsHealthCheck(this Activity activity) =>
 			string.Equals(
-				activity.GetBaggageItem(HealthCheckMarkerKey),
-				HealthCheckMarkerValue,
+				activity.GetBaggageItem(s_healthCheckMarkerKey),
+				s_healthCheckMarkerValue,
 				StringComparison.OrdinalIgnoreCase);
 
 		/// <summary>
@@ -45,8 +45,8 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		/// <remarks>Currently added to the BaggageItems (via Kestrel) using header value Correlation-Context: "PerformanceTestMarker=true"</remarks>
 		public static bool IsPerformanceTest(this Activity activity) =>
 			string.Equals(
-				activity.GetBaggageItem(PerformanceMarkerKey),
-				PerformanceMarkerValue,
+				activity.GetBaggageItem(s_performanceMarkerKey),
+				s_performanceMarkerValue,
 				StringComparison.OrdinalIgnoreCase);
 
 		/// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		/// </summary>
 		/// <remarks>This property would be transfered to child activity and via web requests</remarks>
 		public static Activity SetUserHash(this Activity activity, string userHash) =>
-			activity.SetBaggage(UserHashKey, userHash);
+			activity.SetBaggage(s_userHashKey, userHash);
 
 		/// <summary>
 		/// Mark as health check activity
@@ -63,7 +63,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		public static Activity MarkAsHealthCheck(this Activity activity) =>
 			activity.IsHealthCheck()
 				? activity
-				: activity.SetBaggage(HealthCheckMarkerKey, HealthCheckMarkerValue);
+				: activity.SetBaggage(s_healthCheckMarkerKey, s_healthCheckMarkerValue);
 
 		/// <summary>
 		/// Set result
@@ -109,9 +109,9 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		/// </summary>
 		[Obsolete(CorrelationIdObsoleteMessage, false)]
 		public static Guid? GetObsoleteCorrelationId(this Activity activity) =>
-			Guid.TryParse(activity.GetBaggageItem(ObsoleteCorrelationId), out Guid correlation)
+			Guid.TryParse(activity.GetBaggageItem(s_obsoleteCorrelationId), out Guid correlation)
 				? correlation
-				: (Guid?)null;
+				: null;
 
 		/// <summary>
 		/// Set correlation guid that is used by old Omex services
@@ -119,16 +119,16 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		/// <remarks>This property would be transfered to child activity and via web requests</remarks>
 		[Obsolete(CorrelationIdObsoleteMessage, false)]
 		public static Activity SetObsoleteCorrelationId(this Activity activity, Guid correlation) =>
-			activity.SetBaggage(ObsoleteCorrelationId, correlation.ToString());
+			activity.SetBaggage(s_obsoleteCorrelationId, correlation.ToString());
 
 		/// <summary>
 		/// Get transaction id that is used by old Omex services
 		/// </summary>
 		[Obsolete(TransactionIdObsoleteMessage, false)]
 		public static uint? GetObsoleteTransactionId(this Activity activity) =>
-			uint.TryParse(activity.GetBaggageItem(ObsoleteTransactionId), out uint transactionId)
+			uint.TryParse(activity.GetBaggageItem(s_obsoleteTransactionId), out uint transactionId)
 				? transactionId
-				: (uint?)null;
+				: null;
 
 		/// <summary>
 		/// Set transaction id that is used by old Omex services
@@ -136,15 +136,15 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		/// <remarks>This property would be transfered to child activity and via web requests</remarks>
 		[Obsolete(TransactionIdObsoleteMessage, false)]
 		public static Activity SetObsoleteTransactionId(this Activity activity, uint transactionId) =>
-			activity.SetBaggage(ObsoleteTransactionId, transactionId.ToString(CultureInfo.InvariantCulture));
+			activity.SetBaggage(s_obsoleteTransactionId, transactionId.ToString(CultureInfo.InvariantCulture));
 
-		private const string UserHashKey = "UserHash";
-		private const string HealthCheckMarkerKey = "HealthCheckMarker";
-		private const string HealthCheckMarkerValue = "true";
-		private const string PerformanceMarkerKey = "PerformanceTestMarker";
-		private const string PerformanceMarkerValue = "true";
-		private const string ObsoleteCorrelationId = "ObsoleteCorrelationId";
-		private const string ObsoleteTransactionId = "ObsoleteTransactionId";
+		private static readonly string s_userHashKey = "UserHash";
+		private static readonly string s_healthCheckMarkerKey = "HealthCheckMarker";
+		private static readonly string s_healthCheckMarkerValue = "true";
+		private static readonly string s_performanceMarkerKey = "PerformanceTestMarker";
+		private static readonly string s_performanceMarkerValue = "true";
+		private static readonly string s_obsoleteCorrelationId = "ObsoleteCorrelationId";
+		private static readonly string s_obsoleteTransactionId = "ObsoleteTransactionId";
 		private const string CorrelationIdObsoleteMessage = "Please use Activity.Id or Activity.GetRootIdAsGuid() for new services instead";
 		private const string TransactionIdObsoleteMessage = "Please use Activity.IsHealthCheck() for new services instead";
 	}

--- a/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Extensions/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -16,19 +16,19 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 	public class BaseExecutionContext : IExecutionContext
 	{
 		// Defined by Azure https://whatazurewebsiteenvironmentvariablesareavailable.azurewebsites.net/
-		internal const string RegionNameVariableName = "REGION_NAME";
+		internal static readonly string RegionNameVariableName = "REGION_NAME";
 
 		// We define them
-		internal const string ClusterNameVariableName = "CLUSTER_NAME";
-		internal const string SliceNameVariableName = "SLICE_NAME";
-		internal const string AspNetCoreEnviromentVariableName = "ASPNETCORE_ENVIRONMENT";
-		internal const string DotNetEnviromentVariableName = "DOTNET_ENVIRONMENT"; // getting environment directly only if we don't have IHostEnvironment ex. InitializationLogger
+		internal static readonly string ClusterNameVariableName = "CLUSTER_NAME";
+		internal static readonly string SliceNameVariableName = "SLICE_NAME";
+		internal static readonly string AspNetCoreEnviromentVariableName = "ASPNETCORE_ENVIRONMENT";
+		internal static readonly string DotNetEnviromentVariableName = "DOTNET_ENVIRONMENT"; // getting environment directly only if we don't have IHostEnvironment ex. InitializationLogger
 
 		// defined by Service Fabric https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-environment-variables-reference
-		internal const string ServiceNameVariableName = "Fabric_ServiceName";
-		internal const string ApplicationNameVariableName = "Fabric_ApplicationName";
-		internal const string NodeNameVariableName = "Fabric_NodeName";
-		internal const string NodeIPOrFQDNVariableName = "Fabric_NodeIPOrFQDN";
+		internal static readonly string ServiceNameVariableName = "Fabric_ServiceName";
+		internal static readonly string ApplicationNameVariableName = "Fabric_ApplicationName";
+		internal static readonly string NodeNameVariableName = "Fabric_NodeName";
+		internal static readonly string NodeIPOrFQDNVariableName = "Fabric_NodeIPOrFQDN";
 
 		/// <summary>
 		/// Create instance of execution context

--- a/src/Extensions/Abstractions/SfConfigurationProvider.cs
+++ b/src/Extensions/Abstractions/SfConfigurationProvider.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Omex.Extensions.Abstractions
 	public class SfConfigurationProvider
 	{
 		/// SF environment variables taken from https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-environment-variables-reference
-		internal const string PublishAddressEvnVariableName = "Fabric_NodeIPOrFQDN";
+		internal static readonly string PublishAddressEvnVariableName = "Fabric_NodeIPOrFQDN";
 
-		internal const string EndpointPortEvnVariableSuffix = "Fabric_Endpoint_";
+		internal static readonly string EndpointPortEvnVariableSuffix = "Fabric_Endpoint_";
 
 		/// <summary>
 		/// Get Service Fabric Variable from environment

--- a/src/Extensions/Activities/Internal/EventSource/ActivityEventSender.cs
+++ b/src/Extensions/Activities/Internal/EventSource/ActivityEventSender.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Omex.Extensions.Activities
 			string userHash = activity.GetUserHash();
 			bool isHealthCheck = activity.IsHealthCheck();
 
-			string subtype = NullPlaceholder;
-			string metadata = NullPlaceholder;
-			string resultAsString = NullPlaceholder;
+			string subtype = s_nullPlaceholder;
+			string metadata = s_nullPlaceholder;
+			string resultAsString = s_nullPlaceholder;
 			foreach (KeyValuePair<string, string?> pair in activity.Tags)
 			{
 				if (pair.Value == null)
@@ -63,7 +63,7 @@ namespace Microsoft.Omex.Extensions.Activities
 #pragma warning disable CS0618 // Until it's used we need to include correlationId into events
 			string correlationId = activity.GetObsoleteCorrelationId()?.ToString()
 				?? activity.GetRootIdAsGuid()?.ToString()
-				?? NullPlaceholder;
+				?? s_nullPlaceholder;
 #pragma warning restore CS0618
 
 			string nameAsString = SanitizeString(name, nameof(name), name);
@@ -116,13 +116,13 @@ namespace Microsoft.Omex.Extensions.Activities
 			return value;
 		}
 
-		private const string StringLimitMessage =
+		private static readonly string StringLimitMessage =
 			"Log aggregation enforces a string length limit of {0} characters per dimension. Truncating length of dimension {1} on activity {2} from {3} chars in order to allow upload of the metric";
 
 		private readonly ActivityEventSource m_eventSource;
 		private readonly string m_serviceName;
 		private readonly ILogger<ActivityEventSender> m_logger;
 		private static readonly string s_logCategory = typeof(ActivityEventSource).FullName ?? nameof(ActivityEventSource);
-		private const string NullPlaceholder = "null";
+		private static readonly string s_nullPlaceholder = "null";
 	}
 }

--- a/src/Extensions/Activities/ServiceCollectionExtensions.cs
+++ b/src/Extensions/Activities/ServiceCollectionExtensions.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Omex.Extensions.Abstractions.Activities.Processing;
 using Microsoft.Omex.Extensions.Abstractions.ExecutionContext;
@@ -18,8 +15,8 @@ namespace Microsoft.Extensions.DependencyInjection
 	/// </summary>
 	public static class ServiceCollectionExtensions
 	{
-		private const string ActivitySourceName = "OmexActivitySource";
-		private const string ActivitySourceVersion = "1.0.0.0";
+		private static readonly string s_activitySourceName = "OmexActivitySource";
+		private static readonly string s_activitySourceVersion = "1.0.0.0";
 
 		/// <summary>
 		/// Add ActivitySource to ServiceCollection
@@ -44,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
 			serviceCollection.TryAddSingleton<IActivitiesEventSender, AggregatedActivitiesEventSender>();
 
 			serviceCollection.TryAddSingleton<IActivityListenerConfigurator, DefaultActivityListenerConfigurator>();
-			serviceCollection.TryAddSingleton(p => new ActivitySource(ActivitySourceName, ActivitySourceVersion));
+			serviceCollection.TryAddSingleton(p => new ActivitySource(s_activitySourceName, s_activitySourceVersion));
 			serviceCollection.TryAddSingleton(p => ActivityEventSource.Instance);
 
 			return serviceCollection;

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/OmexHealthCheckPublisher.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/OmexHealthCheckPublisher.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 		private IHealthStatusSender StatusSender { get; }
 
-		internal const string HealthReportSummaryProperty = "HealthReportSummary";
+		internal static readonly string HealthReportSummaryProperty = "HealthReportSummary";
 
 		public OmexHealthCheckPublisher(IHealthStatusSender statusSender, ObjectPoolProvider objectPoolProvider)
 		{

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthStatusSender.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/RestHealthStatusSender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
 	internal class RestHealthStatusSender : IHealthStatusSender
 	{
-		private const string HealthReportSourceId = nameof(RestHealthStatusSender);
+		private static readonly string s_healthReportSourceId = nameof(RestHealthStatusSender);
 
 		private readonly IServiceFabricClientWrapper m_clientWrapper;
 
@@ -44,7 +44,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			await m_client.Nodes.ReportNodeHealthAsync(
 				nodeName: m_nodeName,
-				healthInformation: new HealthInformation(HealthReportSourceId, checkName, ToSfHealthState(status), description: description));
+				healthInformation: new HealthInformation(s_healthReportSourceId, checkName, ToSfHealthState(status), description: description));
 		}
 
 		private HealthState ToSfHealthState(HealthStatus healthStatus) =>

--- a/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceContextHealthStatusSender.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/Internal/ServiceContextHealthStatusSender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
 	internal class ServiceContextHealthStatusSender : IHealthStatusSender
 	{
-		private const string HealthReportSourceId = nameof(ServiceContextHealthStatusSender);
+		private static readonly string s_healthReportSourceId = nameof(ServiceContextHealthStatusSender);
 
 		private readonly IAccessor<IServicePartition> m_partitionAccessor;
 
@@ -55,7 +55,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 
 			try
 			{
-				m_reportHealth(new HealthInformation(HealthReportSourceId, checkName, ToSfHealthState(status))
+				m_reportHealth(new HealthInformation(s_healthReportSourceId, checkName, ToSfHealthState(status))
 				{
 					Description = description
 				});

--- a/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
+++ b/src/Extensions/Hosting.Services.Web/Middlewares/ObsoleteCorrelationHeadersMiddleware.cs
@@ -55,13 +55,13 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			!IsClientRequest(request)
 			&& Guid.TryParse(ExtractParameter(request.Query, s_correlationIdNames), out Guid correlation)
 				? correlation
-				: (Guid?)null;
+				: null;
 
 		private static Guid? ExtractCorrelationIdFromHeader(HttpRequest request) =>
 			!IsClientRequest(request)
 			&& Guid.TryParse(ExtractHeader(request.Headers, s_correlationIdNames), out Guid correlation)
 				? correlation
-				: (Guid?)null;
+				: null;
 
 		private static string? ExtractParameter(IQueryCollection dataSources, IEnumerable<string> names)
 		{
@@ -100,7 +100,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		/// Checks if the context is for a request that contains identifiers indicating that the request originated from an Office client
 		/// </summary>
 		private static bool IsClientRequest(HttpRequest request) =>
-			request.Headers.ContainsKey(OfficeClientVersionHeader)
+			request.Headers.ContainsKey(s_officeClientVersionHeader)
 				? true
 				: request.Query.Count == 0 // Don't check empty parameters
 					? false
@@ -109,14 +109,18 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		private static uint? ParseUint(string? value) =>
 			uint.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out uint result)
 				? result
-				: (uint?)null;
+				: null;
+
+		private static readonly string s_correlationHeader = "X-CorrelationId";
+
+		private static readonly string s_officeClientVersionHeader = "X-Office-Version";
 
 		private static readonly string[] s_transactionsNames = {
 			"corrtid",					// Correlation transaction query parameter
 			"X-TransactionId" };
 
 		private static readonly string[] s_correlationIdNames = {
-			CorrelationHeader,
+			s_correlationHeader,
 			"MS-CorrelationId",			// Correlation Id header used by other Microsoft services
 			"corr",						// Correlation query parameter
 			"HTTP_X_CORRELATIONID" };
@@ -125,9 +129,5 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 			"client",					// Identifies the client application and platform
 			"av",						// Identifies the client application, platform and partial version
 			"app" };					// Identifies the client application
-
-		private const string CorrelationHeader = "X-CorrelationId";
-
-		private const string OfficeClientVersionHeader = "X-Office-Version";
 	}
 }

--- a/src/Extensions/Logging/Internal/Replayable/ReplayableActivityExtensions.cs
+++ b/src/Extensions/Logging/Internal/Replayable/ReplayableActivityExtensions.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Omex.Extensions.Logging.Internal.Replayable
 {
 	internal static class ReplayebleActivityExtensions
 	{
-		private const string ReplayableLogKey = "ReplayableLogKey";
+		private static readonly string s_replayableLogKey = "ReplayableLogKey";
 
 		private static ConcurrentQueue<LogMessageInformation>? GetReplayableLogsInternal(this Activity activity) =>
-			activity.GetCustomProperty(ReplayableLogKey) as ConcurrentQueue<LogMessageInformation>;
+			activity.GetCustomProperty(s_replayableLogKey) as ConcurrentQueue<LogMessageInformation>;
 
 		public static IEnumerable<LogMessageInformation> GetReplayableLogs(this Activity activity) =>
 			activity.GetReplayableLogsInternal() ?? Enumerable.Empty<LogMessageInformation>();
@@ -25,7 +25,7 @@ namespace Microsoft.Omex.Extensions.Logging.Internal.Replayable
 			if (queue == null)
 			{
 				queue = new ConcurrentQueue<LogMessageInformation>();
-				activity.SetCustomProperty(ReplayableLogKey, queue);
+				activity.SetCustomProperty(s_replayableLogKey, queue);
 			}
 
 			queue.Enqueue(logEvent);

--- a/src/Extensions/ServiceFabricGuest.Abstractions/ServiceFabricRestClientOptions.cs
+++ b/src/Extensions/ServiceFabricGuest.Abstractions/ServiceFabricRestClientOptions.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions
 			return parts.Length < 2 ? DefaultServiceFabricClusterFQDN : string.Join(":", parts.Take(parts.Length - 1));
 		}
 
-		internal const string RuntimeConnectionAddressEvnVariableName = "Fabric_RuntimeConnectionAddress";
+		internal static readonly string RuntimeConnectionAddressEvnVariableName = "Fabric_RuntimeConnectionAddress";
 
-		internal const string DefaultServiceFabricClusterFQDN = "localhost";
+		internal static readonly string DefaultServiceFabricClusterFQDN = "localhost";
 	}
 }

--- a/src/Extensions/Services.Remoting/Internal/Client/ServiceRemotingClientWrapper.cs
+++ b/src/Extensions/Services.Remoting/Internal/Client/ServiceRemotingClientWrapper.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		/// <remarks>
 		/// Should end with RequestOut to be enabled by our telemetry
 		/// </remarks>
-		private const string RequestOutActivitySuffix = "RequestOut";
+		private static readonly string s_requestOutActivitySuffix = "RequestOut";
 
-		private const string OneWayMessageActivityName = Diagnostics.DiagnosticListenerName + "OneWay" + RequestOutActivitySuffix;
+		private static readonly string s_oneWayMessageActivityName = Diagnostics.DiagnosticListenerName + "OneWay" + s_requestOutActivitySuffix;
 
-		private const string RequestActivityName = Diagnostics.DiagnosticListenerName + RequestOutActivitySuffix;
+		private static readonly string s_requestActivityName = Diagnostics.DiagnosticListenerName + s_requestOutActivitySuffix;
 
 		private readonly DiagnosticListener m_diagnosticListener;
 
@@ -58,7 +58,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 
 		public async Task<IServiceRemotingResponseMessage> RequestResponseAsync(IServiceRemotingRequestMessage requestMessage)
 		{
-			Activity? activity = m_diagnosticListener.CreateAndStartActivity(RequestActivityName);
+			Activity? activity = m_diagnosticListener.CreateAndStartActivity(s_requestActivityName);
 			requestMessage.AttachActivityToOutgoingRequest(activity);
 			IServiceRemotingResponseMessage? responseMessage = null;
 
@@ -82,7 +82,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 
 		public void SendOneWay(IServiceRemotingRequestMessage requestMessage)
 		{
-			Activity? activity = m_diagnosticListener.CreateAndStartActivity(OneWayMessageActivityName);
+			Activity? activity = m_diagnosticListener.CreateAndStartActivity(s_oneWayMessageActivityName);
 			requestMessage.AttachActivityToOutgoingRequest(activity);
 
 			try

--- a/src/Extensions/Services.Remoting/Internal/Diagnostics.cs
+++ b/src/Extensions/Services.Remoting/Internal/Diagnostics.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 		/// <remarks>
 		/// Changing this name will mean that consumers might miss telemetry events
 		/// </remarks>
-		internal const string DiagnosticListenerName = "Microsoft.Omex.Extensions.Services.Remoting";
+		internal static readonly string DiagnosticListenerName = "Microsoft.Omex.Extensions.Services.Remoting";
 
 		/// <summary>
 		/// Name of the exception event
@@ -22,7 +22,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 		/// <remarks>
 		/// Should end with Exception to be enabled by our telemetry
 		/// </remarks>
-		private const string ExceptionEventName = DiagnosticListenerName + ".Exception";
+		private static readonly string s_exceptionEventName = DiagnosticListenerName + ".Exception";
 
 		public static DiagnosticListener DefaultListener { get; } = new DiagnosticListener(DiagnosticListenerName);
 
@@ -48,9 +48,9 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 
 		public static void ReportException(this DiagnosticListener listener, Exception exception)
 		{
-			if (listener.IsEnabled(ExceptionEventName))
+			if (listener.IsEnabled(s_exceptionEventName))
 			{
-				listener.Write(ExceptionEventName, exception);
+				listener.Write(s_exceptionEventName, exception);
 			}
 		}
 	}

--- a/src/Extensions/Services.Remoting/OmexRemotingHeadersExtensions.cs
+++ b/src/Extensions/Services.Remoting/OmexRemotingHeadersExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 		/// W3C standard for trace context parent 'traceparent', so we've added omex to avoid conflicts if support would be added in future
 		/// link: https://www.w3.org/TR/trace-context/
 		/// </remarks>
-		private const string TraceParentHeaderName = "omex-traceparent";
+		private static readonly string s_traceParentHeaderName = "omex-traceparent";
 
 		/// <summary>
 		/// Header name for passing <see cref="Activity" /> baggage
@@ -38,7 +38,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 		/// W3C standard for trace context parent 'tracestate', so we've added omex to avoid conflicts if support would be added in future
 		/// link: https://www.w3.org/TR/trace-context/
 		/// </remarks>
-		private const string TraceStateHeaderName = "omex-tracestate";
+		private static readonly string s_traceStateHeaderName = "omex-tracestate";
 
 		private static readonly Encoding s_encoding = Encoding.Unicode;
 
@@ -53,10 +53,10 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 			}
 
 			IServiceRemotingRequestMessageHeader header = requestMessage.GetHeader();
-			if (!header.TryGetHeaderValue(TraceParentHeaderName, out byte[] _)) // header update not supported
+			if (!header.TryGetHeaderValue(s_traceParentHeaderName, out byte[] _)) // header update not supported
 			{
-				header.AddHeader(TraceParentHeaderName, s_encoding.GetBytes(activity.Id));
-				header.AddHeader(TraceStateHeaderName, SerializeBaggage(activity.Baggage.ToArray()));
+				header.AddHeader(s_traceParentHeaderName, s_encoding.GetBytes(activity.Id));
+				header.AddHeader(s_traceStateHeaderName, SerializeBaggage(activity.Baggage.ToArray()));
 			}
 		}
 
@@ -73,7 +73,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 			IServiceRemotingRequestMessageHeader headers = requestMessage.GetHeader();
 
 			string parentId = string.Empty;
-			if (headers.TryGetHeaderValue(TraceParentHeaderName, out byte[] idBytes))
+			if (headers.TryGetHeaderValue(s_traceParentHeaderName, out byte[] idBytes))
 			{
 				parentId = s_encoding.GetString(idBytes);
 			}
@@ -85,7 +85,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 				return null;
 			}
 
-			if (headers.TryGetHeaderValue(TraceStateHeaderName, out byte[] baggageBytes))
+			if (headers.TryGetHeaderValue(s_traceStateHeaderName, out byte[] baggageBytes))
 			{
 				KeyValuePair<string, string>[] baggage = DeserializeBaggage(baggageBytes);
 
@@ -103,14 +103,14 @@ namespace Microsoft.Omex.Extensions.Services.Remoting
 
 		private static byte[] SerializeBaggage(KeyValuePair<string, string?>[] baggage)
 		{
-			using MemoryStream stream = new MemoryStream();
+			using MemoryStream stream = new();
 			s_serializer.WriteObject(stream, baggage);
 			return stream.ToArray();
 		}
 
 		private static KeyValuePair<string, string>[] DeserializeBaggage(byte[] bytes)
 		{
-			using MemoryStream stream = new MemoryStream(bytes);
+			using MemoryStream stream = new(bytes);
 			return s_serializer.ReadObject(stream) as KeyValuePair<string, string>[]
 				?? Array.Empty<KeyValuePair<string, string>>();
 		}

--- a/src/Extensions/Services.Remoting/Runtime/OmexServiceRemotingDispatcher.cs
+++ b/src/Extensions/Services.Remoting/Runtime/OmexServiceRemotingDispatcher.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Runtime
 		/// <remarks>
 		/// Should end with RequestIn to be enabled by our telemetry
 		/// </remarks>
-		private const string RequestInActivitySuffix = "RequestIn";
+		private static readonly string s_requestInActivitySuffix = "RequestIn";
 
-		private const string OneWayMessageActivityName = Diagnostics.DiagnosticListenerName + "OneWay" + RequestInActivitySuffix;
+		private static readonly string s_oneWayMessageActivityName = Diagnostics.DiagnosticListenerName + "OneWay" + s_requestInActivitySuffix;
 
-		private const string RequestActivityName = Diagnostics.DiagnosticListenerName + RequestInActivitySuffix;
+		private static readonly string s_requestActivityName = Diagnostics.DiagnosticListenerName + s_requestInActivitySuffix;
 
 		private readonly DiagnosticListener m_diagnosticListener;
 
@@ -49,7 +49,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Runtime
 
 			try
 			{
-				activity = requestMessage.StartActivityFromIncomingRequest(m_diagnosticListener, OneWayMessageActivityName);
+				activity = requestMessage.StartActivityFromIncomingRequest(m_diagnosticListener, s_oneWayMessageActivityName);
 				base.HandleOneWayMessage(requestMessage);
 				activity?.SetResult(ActivityResult.Success);
 			}
@@ -75,7 +75,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Runtime
 
 			try
 			{
-				activity = requestMessage.StartActivityFromIncomingRequest(m_diagnosticListener, RequestActivityName);
+				activity = requestMessage.StartActivityFromIncomingRequest(m_diagnosticListener, s_requestActivityName);
 				responseMessage = await base.HandleRequestResponseAsync(requestContext, requestMessage).ConfigureAwait(false);
 				activity?.SetResult(ActivityResult.Success);
 			}


### PR DESCRIPTION
Using `const` results in a new allocation each time it's used. The most common exception would be health check markers we have that used each time we mark activity as healthcheck or check it.

This PR replaces `const` with `static readonly` to avoid additional allocations. 