### PR TITLE
Remove .NET 5 from targets

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 
 # [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT="5.0"
+ARG VARIANT="6.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
-
-# Add .NET Core 3.1 runtime.
-COPY --from=mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim /usr/share/dotnet /usr/share/dotnet
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
-    - uses: actions/setup-dotnet@v1
-      with:
         dotnet-version: '6.0.x'
     - name: Build with dotnet
       run: dotnet build --configuration ${{ matrix.configuration }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="$(MSBuildThisFileDirectory)\Dependencies.props" />
   <PropertyGroup Label="Target Platforms" >
-    <NetCoreVersions>net5.0;net6.0</NetCoreVersions>
+    <NetCoreVersions>net6.0</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>
     <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>


### PR DESCRIPTION
No need of targeting it explicitly, since most of the consumers updated or can use `.netstandard2.0` dll.