### PR TITLE
Removed explicit references to out-of-support packages

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -2,10 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Package Versions. AutoUpdate">
     <Moq_Version>4.16.1</Moq_Version>
-    <Microsoft_AspNetCore_Hosting_Abstractions_Version>2.2.0</Microsoft_AspNetCore_Hosting_Abstractions_Version>
-    <Microsoft_AspNetCore_Hosting_Version>2.2.7</Microsoft_AspNetCore_Hosting_Version>
-    <Microsoft_AspNetCore_Http_Abstractions_Version>2.2.0</Microsoft_AspNetCore_Http_Abstractions_Version>
-    <Microsoft_AspNetCore_Http_Version>2.2.2</Microsoft_AspNetCore_Http_Version>
     <Microsoft_Azure_DocumentDB_Version>2.16.2</Microsoft_Azure_DocumentDB_Version>
     <Microsoft_CodeAnalysis_Common>3.11.0</Microsoft_CodeAnalysis_Common>
     <Microsoft_CodeAnalysis_Csharp>3.11.0</Microsoft_CodeAnalysis_Csharp>
@@ -16,7 +12,6 @@
     <MSTest_TestFramework_Version>2.2.8</MSTest_TestFramework_Version>
     <System_Configuration_ConfigurationManager_Version>6.0.0</System_Configuration_ConfigurationManager_Version>
     <System_ServiceModel_Primitives_Version>4.9.0</System_ServiceModel_Primitives_Version>
-    <System_Text_Encodings_Web_Version>6.0.0</System_Text_Encodings_Web_Version>
     <System_Threading_Tasks_Version>4.3.0</System_Threading_Tasks_Version>
     <System_Text_Json_Version>6.0.0</System_Text_Json_Version>
     <System_ComponentModel_Annotations>5.0.0</System_ComponentModel_Annotations>

--- a/src/Extensions/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
+++ b/src/Extensions/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="$(Microsoft_ServiceFabric_Services_Remoting_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" /> <!-- Override due to CG vulnerability -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hosting.Services\Microsoft.Omex.Extensions.Hosting.Services.csproj" />

--- a/src/Extensions/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
+++ b/src/Extensions/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
@@ -16,9 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="$(Microsoft_ServiceFabric_AspNetCore_Abstractions_Version)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(Microsoft_AspNetCore_Hosting_Version)" /> <!-- Override due to CG vulnerability -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(Microsoft_AspNetCore_Http_Version)" /> <!-- Override due to CG vulnerability -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" /> <!-- Override due to CG vulnerability -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hosting.Services\Microsoft.Omex.Extensions.Hosting.Services.csproj" />

--- a/src/Extensions/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
+++ b/src/Extensions/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(Microsoft_ServiceFabric_Version)" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(Microsoft_ServiceFabric_Services_Version)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" /> <!-- Override due to CG vulnerability -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hosting\Microsoft.Omex.Extensions.Hosting.csproj" />

--- a/src/Extensions/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Extensions/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(Microsoft_Extensions_Logging_Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(Microsoft_Extensions_Logging_Console_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" /> <!-- Override due to CG vulnerability -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/tests/Extensions/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
+++ b/tests/Extensions/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
+++ b/tests/Extensions/Compatibility.UlsLoggerAdapter.UnitTests/Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.UnitTests.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extensions_Hosting_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Extensions\Compatibility.UlsLoggerAdapter\Microsoft.Omex.Extensions.Compatibility.UlsLoggerAdapter.csproj" />

--- a/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
+++ b/tests/Gating.UnitTests/Microsoft.Omex.Gating.UnitTests.csproj
@@ -16,10 +16,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <ItemGroup Condition="$(IsNetCore)">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(Microsoft_AspNetCore_Http_Abstractions_Version)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(System_Text_Encodings_Web_Version)" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="DefaultGates.xml" Link="DefaultGates.xml">
       <LogicalName>DefaultGates.xml</LogicalName>


### PR DESCRIPTION
Projects have been upgraded to net6.0 and netstandard2.0, explicit overrides for aspnetcore2.2 are not needed anymore.