### PR TITLE
Use healthcheck name for wrapping activity

### DIFF
--- a/src/Extensions/Diagnostics.HealthChecks/AbstractHealthCheck.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/AbstractHealthCheck.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <inheritdoc />
 		public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken token = default)
 		{
-			using Activity? activity = m_activitySource.StartActivity(context.Registration.Name)
+			string activityName = string.IsNullOrWhiteSpace(context.Registration.Name) ? "HealthCheckActivity" : context.Registration.Name; 
+			using Activity? activity = m_activitySource.StartActivity(activityName)
 				?.MarkAsSystemError()
 				.MarkAsHealthCheck();
 

--- a/src/Extensions/Diagnostics.HealthChecks/AbstractHealthCheck.cs
+++ b/src/Extensions/Diagnostics.HealthChecks/AbstractHealthCheck.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <inheritdoc />
 		public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken token = default)
 		{
-			using Activity? activity = m_activitySource.StartActivity("HealthCheckActivity")
+			using Activity? activity = m_activitySource.StartActivity(context.Registration.Name)
 				?.MarkAsSystemError()
 				.MarkAsHealthCheck();
 


### PR DESCRIPTION
We are currently using the constant name for the activity that wraps the health check, with this change it would be named the same as healthcheck.