### PR TITLE
DiagnosticsObserverInitializer: remove payload from logs

### DIFF
--- a/src/Activities/Internal/DiagnosticsListener/DiagnosticsObserversInitializer.cs
+++ b/src/Activities/Internal/DiagnosticsListener/DiagnosticsObserversInitializer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Omex.Extensions.Activities
 			m_logger.LogError(
 				Tag.Create(),
 				ExtractExceptionFromPayload(payload),
-				"Exception diagnostic event '{0}' with payload '{1}'", eventName, payload);
+				"Exception diagnostic event '{0}'.", eventName);
 
 
 		// Made internal for unit testing


### PR DESCRIPTION
DiagnosticsObserverInitializer is logging full requests (including authorization headers when they exists) when the HttpRequestException is thrown.

![image](https://user-images.githubusercontent.com/8594708/153433260-06b4c5fc-6149-4edc-a719-95640888bfa4.png)

This is because the System.Net.Http.Exception event [passes an ExceptionData instance to the payload](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L169)  , whose [ToString() overload](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L268)  prints out the exception (once more as it is also logged by the LogError(eventId, Exception, message)), and the full request including its headers as part of [its ToString overload](https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System/net/System/Net/Http/HttpRequestMessage.cs#L172)  that calls the HeaderUtils function [DumpHeaders](https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System/net/System/Net/Http/Headers/HeaderUtilities.cs#L257) 

We could consider logging the request redacting the auth header (we would need to use reflection since the class is private), but I think until that happens would be better to just drop it from the logs.

@Garth Hunter will engage with the .net team to see if it is the expected behaviour to add all headers in the ToString method since it makes it fairly easy to log auth headers without the intention to do so.