### PR TITLE
Dimeehan/log scrubber: accept MatchEvaluator for custom regex replacement logic

### DIFF
--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
 		/// </summary>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
-		/// <param name="matchEvaluator">The value with which to replace the matching text.</param>
+		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
 		public RegexLogScrubbingRule(string regexToReplace, MatchEvaluator? matchEvaluator)
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -43,18 +43,9 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <returns>The scrubbed input.</returns>
 		public string Scrub(string input)
 		{
-			string scrubbedResult = string.Empty;
-
-			if (m_matchEvaluator != null)
-			{
-				scrubbedResult = m_regexToReplace.Replace(input, m_matchEvaluator);
-			}
-			else
-			{
-				scrubbedResult = m_regexToReplace.Replace(input, m_replacementValue ?? string.Empty);
-			}
-
-			return scrubbedResult;
+			return m_matchEvaluator != null
+				? m_regexToReplace.Replace(input, m_matchEvaluator)
+				: m_regexToReplace.Replace(input, m_replacementValue ?? string.Empty);
 		}
 	}
 }

--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 	internal class RegexLogScrubbingRule : ILogScrubbingRule
 	{
 		private readonly Regex m_regexToReplace;
-		private readonly string m_replacementValue;
-		private readonly MatchEvaluator m_matchEvaluator;
+		private readonly string? m_replacementValue;
+		private readonly MatchEvaluator? m_matchEvaluator;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
@@ -23,7 +23,6 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_replacementValue = replacementValue;
-			m_matchEvaluator = null!;
 		}
 
 		/// <summary>
@@ -35,7 +34,6 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_matchEvaluator = matchEvaluator;
-			m_replacementValue = string.Empty;
 		}
 
 		/// <summary>

--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -11,20 +11,31 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 	internal class RegexLogScrubbingRule : ILogScrubbingRule
 	{
 		private readonly Regex m_regexToReplace;
-		private readonly MatchEvaluator? m_matchEvaluator;
-		private readonly string? m_replacementValue;
+		private readonly string m_replacementValue;
+		private readonly MatchEvaluator m_matchEvaluator;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
 		/// </summary>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
-		public RegexLogScrubbingRule(string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
+		public RegexLogScrubbingRule(string regexToReplace, string replacementValue)
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_replacementValue = replacementValue;
+			m_matchEvaluator = null!;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
+		/// </summary>
+		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
+		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
+		public RegexLogScrubbingRule(string regexToReplace, MatchEvaluator matchEvaluator)
+		{
+			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_matchEvaluator = matchEvaluator;
+			m_replacementValue = string.Empty;
 		}
 
 		/// <summary>

--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -19,20 +19,11 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// </summary>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		public RegexLogScrubbingRule(string regexToReplace, string? replacementValue)
+		/// <param name="matchEvaluator"></param>
+		public RegexLogScrubbingRule(string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_replacementValue = replacementValue;
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
-		/// </summary>
-		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
-		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
-		public RegexLogScrubbingRule(string regexToReplace, MatchEvaluator? matchEvaluator)
-		{
-			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_matchEvaluator = matchEvaluator;
 		}
 

--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -11,17 +11,29 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 	internal class RegexLogScrubbingRule : ILogScrubbingRule
 	{
 		private readonly Regex m_regexToReplace;
-		private readonly string m_replacementValue;
+		private readonly MatchEvaluator? m_matchEvaluator;
+		private readonly string? m_replacementValue;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
 		/// </summary>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		public RegexLogScrubbingRule(string regexToReplace, string replacementValue)
+		public RegexLogScrubbingRule(string regexToReplace, string? replacementValue)
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 			m_replacementValue = replacementValue;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RegexLogScrubbingRule"/> class.
+		/// </summary>
+		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
+		/// <param name="matchEvaluator">The value with which to replace the matching text.</param>
+		public RegexLogScrubbingRule(string regexToReplace, MatchEvaluator? matchEvaluator)
+		{
+			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+			m_matchEvaluator = matchEvaluator;
 		}
 
 		/// <summary>
@@ -29,7 +41,20 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// </summary>
 		/// <param name="input">The input to scrub.</param>
 		/// <returns>The scrubbed input.</returns>
-		public string Scrub(string input) =>
-			m_regexToReplace.Replace(input, m_replacementValue);
+		public string Scrub(string input)
+		{
+			string scrubbedResult = string.Empty;
+
+			if (m_matchEvaluator != null)
+			{
+				scrubbedResult = m_regexToReplace.Replace(input, m_matchEvaluator);
+			}
+			else
+			{
+				scrubbedResult = m_regexToReplace.Replace(input, m_replacementValue ?? string.Empty);
+			}
+
+			return scrubbedResult;
+		}
 	}
 }

--- a/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
+++ b/src/Logging/Scrubbing/RegexLogScrubbingRule.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// </summary>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		/// <param name="matchEvaluator"></param>
+		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
 		public RegexLogScrubbingRule(string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
 		{
 			m_regexToReplace = new Regex(regexToReplace, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// </summary>
 		/// <param name="builder">The extension method argument.</param>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
-		/// <param name="matchEvaluator"></param>
+		/// <param name="matchEvaluator">Custom logic for regex replace</param>
 		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
 		{
 			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, matchEvaluator));

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <param name="builder">The extension method argument.</param>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
+		/// <remarks>
+		/// Please be advised that using MatchEvaluator for Regex replace is a
+		/// more expensive operation compared to simple string replace of the entire regex. After running
+		/// unit tests locally, we can see roughly a 28.57% difference (increase of about 33%).
+		/// </remarks>
 		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
 		{
 			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, matchEvaluator));

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +21,18 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string replacementValue)
 		{
 			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue));
+			return builder;
+		}
+
+		/// <summary>
+		/// Adds a regular expression log scrubbing rule.
+		/// </summary>
+		/// <param name="builder">The extension method argument.</param>
+		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
+		/// <param name="matchEvaluator"></param>
+		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
+		{
+			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, matchEvaluator));
 			return builder;
 		}
 

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <remarks>
 		/// Please be advised that using MatchEvaluator for Regex replace is a
 		/// more expensive operation compared to simple string replace of the entire regex. After running
-		/// unit tests locally, we can see roughly a 28.57% difference (increase of about 33%).
+		/// unit test profiler locally, we can see there is roughly a 31% increase when using the evaluator. 
 		/// </remarks>
 		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
 		{

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <param name="builder">The extension method argument.</param>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		/// <param name="matchEvaluator"></param>
+		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
 		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
 		{
 			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue, matchEvaluator));

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -18,21 +18,10 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <param name="builder">The extension method argument.</param>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string replacementValue)
+		/// <param name="matchEvaluator"></param>
+		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
 		{
-			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue));
-			return builder;
-		}
-
-		/// <summary>
-		/// Adds a regular expression log scrubbing rule.
-		/// </summary>
-		/// <param name="builder">The extension method argument.</param>
-		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
-		/// <param name="matchEvaluator">Custom logic for regex replace</param>
-		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
-		{
-			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, matchEvaluator));
+			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue, matchEvaluator));
 			return builder;
 		}
 

--- a/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
+++ b/src/Logging/Scrubbing/ServiceCollectionExtensions.cs
@@ -18,10 +18,21 @@ namespace Microsoft.Omex.Extensions.Logging.Scrubbing
 		/// <param name="builder">The extension method argument.</param>
 		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
 		/// <param name="replacementValue">The value with which to replace the matching text.</param>
-		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
-		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string? replacementValue = null, MatchEvaluator? matchEvaluator = null)
+		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, string replacementValue)
 		{
-			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue, matchEvaluator));
+			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, replacementValue));
+			return builder;
+		}
+
+		/// <summary>
+		/// Adds a regular expression log scrubbing rule.
+		/// </summary>
+		/// <param name="builder">The extension method argument.</param>
+		/// <param name="regexToReplace">The regular expression specifying the strings to replace.</param>
+		/// <param name="matchEvaluator">Custom logic for regex replace.</param>
+		public static ILoggingBuilder AddRegexLogScrubbingRule(this ILoggingBuilder builder, string regexToReplace, MatchEvaluator matchEvaluator)
+		{
+			builder.Services.AddSingleton<ILogScrubbingRule>(_ => new RegexLogScrubbingRule(regexToReplace, matchEvaluator));
 			return builder;
 		}
 

--- a/tests/Logging.UnitTests/Scrubbing/RegexLogScrubbingRuleTests.cs
+++ b/tests/Logging.UnitTests/Scrubbing/RegexLogScrubbingRuleTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Text.RegularExpressions;
 using Microsoft.Omex.Extensions.Logging.Scrubbing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -23,6 +24,29 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 		public void Scrub_ShouldScrub(string input, string expected)
 		{
 			RegexLogScrubbingRule scrubber = new("input*", "[REDACTED]");
+
+			Assert.AreEqual(expected, scrubber.Scrub(input));
+		}
+
+		[DataTestMethod]
+		[DataRow("/api/path?q1=v1&q2=v2&q3=v3", "/api/path?REDACTED&REDACTED&q3=v3")]
+		[DataRow("/api/path?q1=v1&q2=v2", "/api/path?REDACTED&REDACTED&")]
+		[DataRow("/api/path?q3=v3", "/api/path?q3=v3")]
+		public void Scrub_ShouldScrub_WithoutMatchEvaluator(string input, string expected)
+		{
+			RegexLogScrubbingRule scrubber = new("(q1|q2)=(.+?)(&|$)", "REDACTED&");
+
+			Assert.AreEqual(expected, scrubber.Scrub(input));
+		}
+
+		[DataTestMethod]
+		[DataRow("/api/path?q1=v1&q2=v2&q3=v3", "/api/path?q1=REDACTED&q2=REDACTED&q3=v3")]
+		[DataRow("/api/path?q1=v1&q2=v2", "/api/path?q1=REDACTED&q2=REDACTED")]
+		[DataRow("/api/path?q3=v3", "/api/path?q3=v3")]
+		public void Scrub_ShouldScrub_WithMatchEvaluator(string input, string expected)
+		{
+			MatchEvaluator matchEvaluator = new((match) => match.Groups[1].Value + "=REDACTED" + match.Groups[3].Value);
+			RegexLogScrubbingRule scrubber = new("(q1|q2)=(.+?)(&|$)", matchEvaluator);
 
 			Assert.AreEqual(expected, scrubber.Scrub(input));
 		}

--- a/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
+++ b/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 		[DataRow("/api/path?q1=v1&q2=v2&q3=v3", "/api/path?q1=REDACTED&q2=REDACTED&q3=v3")]
 		[DataRow("/api/path?q1=v1&q2=v2", "/api/path?q1=REDACTED&q2=REDACTED")]
 		[DataRow("/api/path?q3=v3", "/api/path?q3=v3")]
-		public void Scrub_Url_WithMatchEvaluator_ShouldScrub(string input, string expected)
+		public void AddRegexLogScrubbingRule_WithMatchEvaluator_Scrubs(string input, string expected)
 		{
 			MatchEvaluator matchEvaluator = new((match) => match.Groups[1].Value + "=REDACTED" + match.Groups[3].Value);
 
@@ -130,7 +130,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 		[DataRow("/api/path?q1=v1&q2=v2&q3=v3", "/api/path?REDACTED&REDACTED&q3=v3")]
 		[DataRow("/api/path?q1=v1&q2=v2", "/api/path?REDACTED&REDACTED&")]
 		[DataRow("/api/path?q3=v3", "/api/path?q3=v3")]
-		public void Scrub_Url_WithoutMatchEvaluator_ShouldScrub(string input, string expected)
+		public void AddRegexLogScrubbingRule_Scrubs(string input, string expected)
 		{
 			ILoggingBuilder builder2 = new MockLoggingBuilder()
 				.AddRegexLogScrubbingRule(Regex,"REDACTED&");

--- a/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
+++ b/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 			MatchEvaluator matchEvaluator = new((match) => match.Groups[1].Value + "=REDACTED" + match.Groups[3].Value);
 
 			ILoggingBuilder builder2 = new MockLoggingBuilder()
-				.AddRegexLogScrubbingRule(Regex, matchEvaluator: matchEvaluator);
+				.AddRegexLogScrubbingRule(Regex, matchEvaluator);
 
 			ILogScrubbingRule[] logScrubbingRules = GetTypeRegistrations(builder2.Services);
 

--- a/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
+++ b/tests/Logging.UnitTests/Scrubbing/ServiceCollectionExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 			MatchEvaluator matchEvaluator = new((match) => match.Groups[1].Value + "=REDACTED" + match.Groups[3].Value);
 
 			ILoggingBuilder builder2 = new MockLoggingBuilder()
-				.AddRegexLogScrubbingRule(Regex, matchEvaluator);
+				.AddRegexLogScrubbingRule(Regex, matchEvaluator: matchEvaluator);
 
 			ILogScrubbingRule[] logScrubbingRules = GetTypeRegistrations(builder2.Services);
 
@@ -133,7 +133,7 @@ namespace Microsoft.Omex.Extensions.Logging.UnitTests.Scrubbing
 		public void Scrub_Url_WithoutMatchEvaluator_ShouldScrub(string input, string expected)
 		{
 			ILoggingBuilder builder2 = new MockLoggingBuilder()
-				.AddRegexLogScrubbingRule(Regex, "REDACTED&");
+				.AddRegexLogScrubbingRule(Regex,"REDACTED&");
 
 			ILogScrubbingRule[] logScrubbingRules = GetTypeRegistrations(builder2.Services);
 


### PR DESCRIPTION
Updating this logic to accept matchevaluator for log scrubbing in Omex. Currently, it scrubs the entire key and value with REDACTED which makes it difficult to read and debug. 

Scrub q1 and q2 query params:
Input: https://api.host.com/appinstall?q1=abc&p1=444&p2=555&q2=def
Current post-scrub: https://api.host.com/appinstall?REDACTED&p1=444&p2=555&REDACTED
Wanted post-scrub: https://api.host.com/appinstall?q1=REDACTED&p1=444&p2=555&q2=REDACTED
