### PR TITLE
Workaround for .NET 6.0.2 regression.

### DIFF
--- a/src/CodeGenerators/SettingsGen/BaseGenerator.cs
+++ b/src/CodeGenerators/SettingsGen/BaseGenerator.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 		/// <summary>
 		/// Writing to a file
 		/// </summary>
-		protected static readonly DiagnosticDescriptor WritingToFile = new(id: "SETTINGSGEN001",
+		protected static readonly DiagnosticDescriptor WritingToFile = new DiagnosticDescriptor(id: "SETTINGSGEN001",
 			title: "Writing to settings file",
 			messageFormat: "Writing to file '{0}'",
 			category: "SettingsGenerator",
@@ -107,7 +107,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 		/// <summary>
 		/// Don't generate
 		/// </summary>
-		protected static readonly DiagnosticDescriptor DontGen = new(id: "SETTINGSGEN002",
+		protected static readonly DiagnosticDescriptor DontGen = new DiagnosticDescriptor(id: "SETTINGSGEN002",
 			title: "Not generating",
 			messageFormat: "Not generating/updating settings file",
 			category: "SettingsGenerator",
@@ -117,7 +117,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 		/// <summary>
 		/// Matching settings
 		/// </summary>
-		protected static readonly DiagnosticDescriptor MatchingSettings = new(id: "SETTINGSGEN003",
+		protected static readonly DiagnosticDescriptor MatchingSettings = new DiagnosticDescriptor(id: "SETTINGSGEN003",
 			title: "Existing settings match",
 			messageFormat: "No new settings or updated settings so don't need to generate",
 			category: "SettingsGenerator",
@@ -127,7 +127,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 		/// <summary>
 		/// Failed to generate
 		/// </summary>
-		protected static readonly DiagnosticDescriptor FailedGeneration = new(id: "SETTINGSGEN004",
+		protected static readonly DiagnosticDescriptor FailedGeneration = new DiagnosticDescriptor(id: "SETTINGSGEN004",
 			title: "Failed with exception",
 			messageFormat: "Failed to write settings generator with error {0}",
 			category: "SettingsGenerator",
@@ -137,7 +137,7 @@ namespace Microsoft.Omex.CodeGenerators.SettingsGen
 		/// <summary>
 		/// Encoutered error in settings gen
 		/// </summary>
-		protected static readonly DiagnosticDescriptor EncounteredError = new(id: "SETTINGSGEN005",
+		protected static readonly DiagnosticDescriptor EncounteredError = new DiagnosticDescriptor(id: "SETTINGSGEN005",
 			title: "Error encountered",
 			messageFormat: "Encountered error {0} when running settings gen",
 			category: "SettingsGenerator",


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/issues/5890

Workaround for build errors in SettingsGen is to not use target-typed new for DiagnosticDescriptor.