### PR TITLE
Workaround for CodeQL build failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Sample build failure: https://github.com/microsoft/Omex/runs/5357713253?check_suite_focus=true 

Error: Tracing builds with **CodeQL is currently not supported on Windows 11 and Windows Server 2022.** 
Please modify your Actions workflow to use an earlier version of Windows for this job, for example by **setting `runs-on: windows-2019`.**
Error: Tracing builds with CodeQL is currently not supported on Windows 11 and Windows Server 2022. Please modify your Actions workflow to use an earlier version of Windows for this job, for example by setting `runs-on: windows-2019`.
    at checkNotWindows11 (D:\a\_actions\github\codeql-action\v1\lib\util.js:533:15)
    at run (D:\a\_actions\github\codeql-action\v1\lib\init-action.js:97:42)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async runWrapper (D:\a\_actions\github\codeql-action\v1\lib\init-action.js:155:9)

https://github.com/actions/virtual-environments/issues/4856 Migration here mentions the following:
1. File an issue in this repository
2. Switch back to windows-2019 by specifying the windows-2019 label in your workflow. We will continue to support Windows Server 2019 image.
