### PR TITLE
Removing references to DocumentDB SDK

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,7 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageReference Update="Moq" Version="4.18.1" />
-    <PackageReference Update="Microsoft.Azure.DocumentDB" Version="2.18.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Csharp" Version="4.2.0" />
     <PackageReference Update="Microsoft.Net.Test.Sdk" Version="17.2.0" />
@@ -18,7 +17,6 @@
     <PackageReference Update="Xunit.Runner.VisualStudio" Version="2.4.5" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. Pinned">
-    <PackageReference Update="Microsoft.Azure.DocumentDb" Version="2.5.1" />
     <PackageReference Update="Xunit.Assert" Version="2.4.1" />
     <PackageReference Update="Xunit.Core" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
The code was removed, but the package reference was left behind.