### PR TITLE
Removing the console logger when running on Service Fabric

### DIFF
--- a/src/Logging/InitializationLogger.cs
+++ b/src/Logging/InitializationLogger.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Omex.Extensions.Logging
 		{
 			// Check if we are running on Service Fabric, if we are not on Service Fabric, add console logging
 			string sfAppName = Environment.GetEnvironmentVariable("Fabric_ApplicationName");
-			bool isSf = sfAppName != null;
+			bool isServiceFabric = sfAppName != null;
 			
-			if (!isSf)
+			if (!isServiceFabric)
 			{
 				builder.AddConsole();
 			}

--- a/src/Logging/InitializationLogger.cs
+++ b/src/Logging/InitializationLogger.cs
@@ -24,7 +24,15 @@ namespace Microsoft.Omex.Extensions.Logging
 
 		private static ILoggingBuilder LoadInitializationLogger(this ILoggingBuilder builder)
 		{
-			builder.AddConsole();
+			// Check if we are running on Service Fabric, if we are not on Service Fabric, add console logging
+			string sfAppName = Environment.GetEnvironmentVariable("Fabric_ApplicationName");
+			bool isSf = sfAppName != null;
+			
+			if (!isSf)
+			{
+				builder.AddConsole();
+			}
+			
 			builder.AddOmexLogging();
 			return builder;
 		}


### PR DESCRIPTION
Check for running on SF used from example here:
https://stackoverflow.com/questions/39781817/how-to-see-if-running-under-service-fabric

This is a suspected issue causing performance issues on apps when running high request counts.