### PR TITLE
Updating transitive version of NewtonSoft being used

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -9,6 +9,7 @@
     <PackageReference Update="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Update="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Update="System.ServiceModel.Primitives" Version="4.9.0" />
     <PackageReference Update="System.Threading.Tasks" Version="4.3.0" />

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="Microsoft.ServiceFabric.Client.Http" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
+++ b/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.ServiceFabric.Client.Http" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 

--- a/tests/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
+++ b/tests/Abstractions.UnitTests/Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Testing.Helpers\Microsoft.Omex.Extensions.Testing.Helpers.csproj" />
   </ItemGroup>

--- a/tests/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
+++ b/tests/Activities.UnitTests/Microsoft.Omex.Extensions.Activities.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
+++ b/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\CodeGenerators\SettingsGen\Microsoft.Omex.CodeGenerators.SettingsGen.csproj" />

--- a/tests/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup Condition="$(IsNetFramework)">

--- a/tests/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
+++ b/tests/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
+++ b/tests/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
+++ b/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
+++ b/tests/Hosting.UnitTests/Microsoft.Omex.Extensions.Hosting.UnitTests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hosting\Microsoft.Omex.Extensions.Hosting.csproj" />

--- a/tests/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
+++ b/tests/Logging.UnitTests/Microsoft.Omex.Extensions.Logging.UnitTests.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Logging\Microsoft.Omex.Extensions.Logging.csproj" />

--- a/tests/ServiceFabricGuest.Abstractions.UnitTests/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests.csproj
+++ b/tests/ServiceFabricGuest.Abstractions.UnitTests/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup Condition="$(IsNetFramework)">

--- a/tests/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
+++ b/tests/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
     <PackageReference Include="ServiceFabric.Mocks" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Testing.Helpers.UnitTests/Microsoft.Omex.Extensions.Testing.Helpers.UnitTests.csproj
+++ b/tests/Testing.Helpers.UnitTests/Microsoft.Omex.Extensions.Testing.Helpers.UnitTests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" /> <!-- Bump version of transitive dependency -->
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Testing.Helpers\Microsoft.Omex.Extensions.Testing.Helpers.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Minimum version 10 is being picked up instead of 13, adding specific references to force the higher version. This is despite     key="dependencyVersion" value="Highest" being specified in the Nuget.config.
Interested if there is a better way to do this.