### PR TITLE
Introduce per-HealthCheckRegistration parameters

### DIFF
--- a/src/Diagnostics.HealthChecks/DependencyInjection/IOmexHealthChecksBuilder.cs
+++ b/src/Diagnostics.HealthChecks/DependencyInjection/IOmexHealthChecksBuilder.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.DependencyInjection;
+
+/// <summary>
+/// A builder used to register health checks.
+/// </summary>
+public interface IOmexHealthChecksBuilder : IHealthChecksBuilder
+{
+	/// <summary>
+	/// Adds a <see cref="HealthCheckRegistration"/> for a health check.
+	/// </summary>
+	/// <param name="registration">The <see cref="HealthCheckRegistration"/>.</param>
+	/// <param name="parameters">The <see cref="HealthCheckRegistrationParameters"/>.</param>
+	IOmexHealthChecksBuilder Add(HealthCheckRegistration registration, HealthCheckRegistrationParameters parameters);
+}

--- a/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthCheckServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthCheckServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides extension methods for registering <see cref="HealthCheckService"/> in an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class OmexHealthCheckServiceCollectionExtensions
+{
+	/// <summary>
+	/// Adds the <see cref="HealthCheckService"/> to the container, using the provided delegate to register
+	/// health checks.
+	/// </summary>
+	/// <remarks>
+	/// This operation is idempotent - multiple invocations will still only result in a single
+	/// <see cref="HealthCheckService"/> instance in the <see cref="IServiceCollection"/>. It can be invoked
+	/// multiple times in order to get access to the <see cref="IOmexHealthChecksBuilder"/> in multiple places.
+	/// </remarks>
+	/// <param name="services">The <see cref="IServiceCollection"/> to add the <see cref="HealthCheckService"/> to.</param>
+	/// <returns>An instance of <see cref="IOmexHealthChecksBuilder"/> from which health checks can be registered.</returns>
+	public static IOmexHealthChecksBuilder AddOmexHealthChecks(this IServiceCollection services)
+	{
+		services.AddHealthChecks(); // Register DefaultHealthCheckService
+
+		// Register OmexHealthCheckPublisherHostedService
+		services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OmexHealthCheckPublisherHostedService>());
+		return new OmexHealthChecksBuilder(services);
+	}
+}

--- a/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilder.cs
+++ b/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilder.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.DependencyInjection;
+
+internal sealed class OmexHealthChecksBuilder : IOmexHealthChecksBuilder
+{
+	public OmexHealthChecksBuilder(IServiceCollection services)
+	{
+		Services = services;
+	}
+
+	public IServiceCollection Services { get; }
+
+	IHealthChecksBuilder IHealthChecksBuilder.Add(HealthCheckRegistration registration)
+	{
+		if (registration == null)
+		{
+			throw new ArgumentNullException(nameof(registration));
+		}
+
+		Services.Configure<HealthCheckServiceOptions>(options =>
+		{
+			options.Registrations.Add(registration);
+		});
+
+		return this;
+	}
+
+	public IOmexHealthChecksBuilder Add(HealthCheckRegistration registration, HealthCheckRegistrationParameters parameters)
+	{
+		if (registration == null)
+		{
+			throw new ArgumentNullException(nameof(registration));
+		}
+
+		if (parameters == null)
+		{
+			throw new ArgumentNullException(nameof(parameters));
+		}
+
+		Services.Configure<HealthCheckServiceOptions>(options =>
+		{
+			options.Registrations.Add(registration);
+		});
+
+		Services.Configure<HealthCheckRegistrationParametersOptions>(options =>
+		{
+			options.RegistrationParameters.Add(registration.Name, parameters);
+		});
+
+		return this;
+	}
+}

--- a/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilderAddCheckExtensions.cs
+++ b/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilderAddCheckExtensions.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0008 // Use explicit type
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+using DynamicallyAccessedMembersAttribute = Microsoft.Omex.Extensions.Diagnostics.HealthChecks.DynamicallyAccessedMembersAttribute;
+using DynamicallyAccessedMemberTypes = Microsoft.Omex.Extensions.Diagnostics.HealthChecks.DynamicallyAccessedMemberTypes;
+using UnconditionalSuppressMessageAttribute = Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnconditionalSuppressMessageAttribute;
+
+namespace Microsoft.Omex.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides basic extension methods for registering <see cref="IHealthCheck"/> instances in an <see cref="IOmexHealthChecksBuilder"/>.
+/// </summary>
+public static class OmexHealthChecksBuilderAddCheckExtensions
+{
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="instance">An <see cref="IHealthCheck"/> instance.</param>
+	/// <param name="failureStatus">
+	/// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
+	/// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+	/// </param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	[SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddCheck(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		IHealthCheck instance,
+		HealthStatus? failureStatus = default,
+		IEnumerable<string>? tags = default,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default)
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (instance == null)
+		{
+			throw new ArgumentNullException(nameof(instance));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderAddCheckExtensions.AddCheck(builder, name, instance, failureStatus, tags, timeout);
+		}
+
+		return builder.Add(new HealthCheckRegistration(name, instance, failureStatus, tags, timeout), parameters);
+	}
+
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <typeparam name="T">The health check implementation type.</typeparam>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="failureStatus">
+	/// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
+	/// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+	/// </param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	/// <remarks>
+	/// This method will use <see cref="ActivatorUtilities.GetServiceOrCreateInstance{T}(IServiceProvider)"/> to create the health check
+	/// instance when needed. If a service of type <typeparamref name="T"/> is registered in the dependency injection container
+	/// with any lifetime it will be used. Otherwise an instance of type <typeparamref name="T"/> will be constructed with
+	/// access to services from the dependency injection container.
+	/// </remarks>
+	[SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddCheck<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		HealthStatus? failureStatus = default,
+		IEnumerable<string>? tags = default,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default) where T : class, IHealthCheck
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderAddCheckExtensions.AddCheck<T>(builder, name, failureStatus, tags, timeout);
+		}
+
+		return builder.Add(new HealthCheckRegistration(name, GetServiceOrCreateInstance, failureStatus, tags, timeout), parameters);
+
+		[UnconditionalSuppressMessage("Trimming", "IL2091",
+		   Justification = "DynamicallyAccessedMemberTypes.PublicConstructors is enforced by calling method.")]
+		static T GetServiceOrCreateInstance(IServiceProvider serviceProvider) =>
+			ActivatorUtilities.GetServiceOrCreateInstance<T>(serviceProvider);
+	}
+
+	/// <summary>
+	/// Adds a new type activated health check with the specified name and implementation.
+	/// </summary>
+	/// <typeparam name="T">The health check implementation type.</typeparam>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="failureStatus">
+	/// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
+	/// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+	/// </param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="args">Additional arguments to provide to the constructor.</param>
+	/// <param name="timeout">A <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	/// <remarks>
+	/// This method will use <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the health check
+	/// instance when needed. Additional arguments can be provided to the constructor via <paramref name="args"/>.
+	/// </remarks>
+	public static IOmexHealthChecksBuilder AddTypeActivatedCheck<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		HealthStatus? failureStatus,
+		IEnumerable<string>? tags,
+		TimeSpan? timeout,
+		HealthCheckRegistrationParameters? parameters,
+		params object[] args) where T : class, IHealthCheck
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderAddCheckExtensions.AddTypeActivatedCheck<T>(builder, name, failureStatus, tags ?? new List<string>(), timeout: timeout ?? Timeout.InfiniteTimeSpan);
+		}
+
+		return builder.Add(new HealthCheckRegistration(name, CreateInstance, failureStatus, tags, timeout), parameters);
+
+		[UnconditionalSuppressMessage("Trimming", "IL2091",
+			Justification = "DynamicallyAccessedMemberTypes.PublicConstructors is enforced by calling method.")]
+		T CreateInstance(IServiceProvider serviceProvider) => ActivatorUtilities.CreateInstance<T>(serviceProvider, args);
+	}
+}

--- a/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilderDelegateExtensions.cs
+++ b/src/Diagnostics.HealthChecks/DependencyInjection/OmexHealthChecksBuilderDelegateExtensions.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0008 // Use explicit type
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides extension methods for registering delegates with the <see cref="IOmexHealthChecksBuilder"/>.
+/// </summary>
+public static class OmexHealthChecksBuilderDelegateExtensions
+{
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="check">A delegate that provides the health check implementation.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	[SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddCheck(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		Func<HealthCheckResult> check,
+		IEnumerable<string>? tags = default,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default)
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (check == null)
+		{
+			throw new ArgumentNullException(nameof(check));
+		}
+
+		if (parameters == null) // Avoids API source breaking
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderDelegateExtensions.AddCheck(builder, name, check, tags, timeout);
+		}
+
+		var instance = new DelegateHealthCheck((ct) => new ValueTask<HealthCheckResult>(check()));
+		return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: default, tags, timeout), parameters);
+	}
+
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="check">A delegate that provides the health check implementation.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	[SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddCheck(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		Func<CancellationToken, HealthCheckResult> check,
+		IEnumerable<string>? tags = default,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default)
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (check == null)
+		{
+			throw new ArgumentNullException(nameof(check));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderDelegateExtensions.AddCheck(builder, name, check, tags, timeout);
+		}
+
+		var instance = new DelegateHealthCheck((ct) => new ValueTask<HealthCheckResult>(check(ct)));
+		return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: default, tags, timeout), parameters);
+	}
+
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="check">A delegate that provides the health check implementation.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	[SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddAsyncCheck(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		Func<ValueTask<HealthCheckResult>> check,
+		IEnumerable<string>? tags = default,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default)
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (check == null)
+		{
+			throw new ArgumentNullException(nameof(check));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderDelegateExtensions.AddAsyncCheck(builder, name, check().AsTask, tags, timeout);
+		}
+
+		var instance = new DelegateHealthCheck((ct) => check());
+		return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: default, tags, timeout), parameters);
+	}
+
+	/// <summary>
+	/// Adds a new health check with the specified name and implementation.
+	/// </summary>
+	/// <param name="builder">The <see cref="IOmexHealthChecksBuilder"/>.</param>
+	/// <param name="name">The name of the health check.</param>
+	/// <param name="tags">A list of tags that can be used to filter health checks.</param>
+	/// <param name="check">A delegate that provides the health check implementation.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+	/// <param name="parameters">An optional <see cref="HealthCheckRegistrationParameters"/> representing the individual health check options.</param>
+	/// <returns>The <see cref="IOmexHealthChecksBuilder"/>.</returns>
+	[SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+	public static IOmexHealthChecksBuilder AddAsyncCheck(
+		this IOmexHealthChecksBuilder builder,
+		string name,
+		Func<CancellationToken, ValueTask<HealthCheckResult>> check,
+		IEnumerable<string>? tags = null,
+		TimeSpan? timeout = default,
+		HealthCheckRegistrationParameters? parameters = default)
+	{
+		if (builder == null)
+		{
+			throw new ArgumentNullException(nameof(builder));
+		}
+
+		if (name == null)
+		{
+			throw new ArgumentNullException(nameof(name));
+		}
+
+		if (check == null)
+		{
+			throw new ArgumentNullException(nameof(check));
+		}
+
+		if (parameters == null)
+		{
+			return (IOmexHealthChecksBuilder)HealthChecksBuilderDelegateExtensions.AddAsyncCheck(builder, name, ct => check(ct).AsTask(), tags, timeout);;
+		}
+
+		var instance = new DelegateHealthCheck((ct) => check(ct));
+		return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: default, tags, timeout), parameters);
+	}
+}

--- a/src/Diagnostics.HealthChecks/HealthCheckRegistrationParameters.cs
+++ b/src/Diagnostics.HealthChecks/HealthCheckRegistrationParameters.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.v
+
+#pragma warning disable IDE0008 // Use explicit type
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Represent the individual health check parameters associated with an <see cref="T:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration"/>.
+/// </summary>
+public class HealthCheckRegistrationParameters : IEquatable<HealthCheckRegistrationParameters?>
+{
+	/// <summary>
+	/// Creates a new <see cref="T:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistrationParameters" />.
+	/// </summary>
+	/// <param name="delay">An optional <see cref="TimeSpan"/> representing the initial delay applied after the application starts before executing the check.</param>
+	/// <param name="period">An optional <see cref="TimeSpan"/> representing the individual period of the check.</param>
+	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the individual timeout of the check.</param>
+	public HealthCheckRegistrationParameters(TimeSpan? delay = default, TimeSpan? period = default, TimeSpan? timeout = default)
+	{
+		Delay = delay;
+		Period = period;
+		Timeout = timeout;
+	}
+
+	/// <summary>
+	/// Gets the initial individual delay applied to the
+	/// individual HealthCheck after the application starts before executing.
+	/// The delay is applied once at startup, and does
+	/// not apply to subsequent iterations.
+	/// </summary>
+	public TimeSpan? Delay { get; }
+
+	/// <summary>
+	/// Gets the individual period used for the check.
+	/// </summary>
+	public TimeSpan? Period { get; }
+
+	/// <summary>
+	/// Gets the timeout for executing the health check.
+	/// Use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to execute with no timeout.
+	/// </summary>
+	public TimeSpan? Timeout { get; }
+
+	/// <inheritdoc/>
+	public override bool Equals(object? obj) => Equals(obj as HealthCheckRegistrationParameters);
+
+	/// <inheritdoc/>
+	public bool Equals(HealthCheckRegistrationParameters? other) => other is not null && EqualityComparer<TimeSpan?>.Default.Equals(Delay, other.Delay) && EqualityComparer<TimeSpan?>.Default.Equals(Period, other.Period) && EqualityComparer<TimeSpan?>.Default.Equals(Timeout, other.Timeout);
+
+	/// <inheritdoc/>
+	public override int GetHashCode() => (Delay, Period, Timeout).GetHashCode();
+}

--- a/src/Diagnostics.HealthChecks/HealthCheckRegistrationParametersOptions.cs
+++ b/src/Diagnostics.HealthChecks/HealthCheckRegistrationParametersOptions.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Represent the individual health check options associated with an <see cref="T:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration"/>.
+/// </summary>
+public sealed class HealthCheckRegistrationParametersOptions
+{
+	/// <summary>
+	/// Gets the health check registrations.
+	/// </summary>
+	public IDictionary<string, HealthCheckRegistrationParameters> RegistrationParameters { get; } = new Dictionary<string, HealthCheckRegistrationParameters>();
+}

--- a/src/Diagnostics.HealthChecks/Internal/DelegateHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Internal/DelegateHealthCheck.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+#pragma warning disable IDE1006 // ASP.NET Core codebase naming convention
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// A simple implementation of <see cref="IHealthCheck"/> which uses a provided delegate to
+/// implement the check.
+/// </summary>
+internal sealed class DelegateHealthCheck : IHealthCheck
+{
+    private readonly Func<CancellationToken, ValueTask<HealthCheckResult>> _check;
+
+    /// <summary>
+    /// Create an instance of <see cref="DelegateHealthCheck"/> from the specified delegate.
+    /// </summary>
+    /// <param name="check">A delegate which provides the code to execute when the health check is run.</param>
+    public DelegateHealthCheck(Func<CancellationToken, ValueTask<HealthCheckResult>> check)
+    {
+        _check = check ?? throw new ArgumentNullException(nameof(check));
+    }
+
+    /// <summary>
+    /// Runs the health check, returning the status of the component being checked.
+    /// </summary>
+    /// <param name="context">A context object associated with the current execution.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the health check.</param>
+    /// <returns>A <see cref="Task{HealthCheckResult}"/> that completes when the health check has finished, yielding the status of the component being checked.</returns>
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default) => _check(cancellationToken).AsTask();
+}

--- a/src/Diagnostics.HealthChecks/Internal/NonCapturingTimer.cs
+++ b/src/Diagnostics.HealthChecks/Internal/NonCapturingTimer.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//Imported from https://github.com/dotnet/aspnetcore/blob/main/src/Shared/NonCapturingTimer/NonCapturingTimer.cs
+
+#nullable enable
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+// A convenience API for interacting with System.Threading.Timer in a way
+// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+// everywhere we use timers to avoid rooting any values stored in asynclocals.
+internal static class NonCapturingTimer
+{
+    public static Timer Create(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        if (callback == null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+        bool restoreFlow = false;
+        try
+        {
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            return new Timer(callback, state, dueTime, period);
+        }
+        finally
+        {
+            // Restore the current ExecutionContext
+            if (restoreFlow)
+            {
+                ExecutionContext.RestoreFlow();
+            }
+        }
+    }
+}

--- a/src/Diagnostics.HealthChecks/Internal/TrimmingAttributes.cs
+++ b/src/Diagnostics.HealthChecks/Internal/TrimmingAttributes.cs
@@ -1,0 +1,239 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Indicates that the specified method requires dynamic access to code that is not referenced
+/// statically, for example through <see cref="System.Reflection"/>.
+/// </summary>
+/// <remarks>
+/// This allows tools to understand which methods are unsafe to call when removing unreferenced
+/// code from an application.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+	/// with the specified message.
+	/// </summary>
+	/// <param name="message">
+	/// A message that contains information about the usage of unreferenced code.
+	/// </param>
+	public RequiresUnreferencedCodeAttribute(string message)
+	{
+		Message = message;
+	}
+
+	/// <summary>
+	/// Gets a message that contains information about the usage of unreferenced code.
+	/// </summary>
+	public string Message { get; }
+
+	/// <summary>
+	/// Gets or sets an optional URL that contains more information about the method,
+	/// why it requires unreferenced code, and what options a consumer has to deal with it.
+	/// </summary>
+	public string? Url { get; set; }
+}
+
+/// <summary>
+/// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+/// single code artifact.
+/// </summary>
+/// <remarks>
+/// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+/// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+/// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+/// </remarks>
+[AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+	/// class, specifying the category of the tool and the identifier for an analysis rule.
+	/// </summary>
+	/// <param name="category">The category for the attribute.</param>
+	/// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+	public UnconditionalSuppressMessageAttribute(string category, string checkId)
+	{
+		Category = category;
+		CheckId = checkId;
+	}
+
+	/// <summary>
+	/// Gets the category identifying the classification of the attribute.
+	/// </summary>
+	/// <remarks>
+	/// The <see cref="Category"/> property describes the tool or tool analysis category
+	/// for which a message suppression attribute applies.
+	/// </remarks>
+	public string Category { get; }
+
+	/// <summary>
+	/// Gets the identifier of the analysis tool rule to be suppressed.
+	/// </summary>
+	/// <remarks>
+	/// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+	/// properties form a unique check identifier.
+	/// </remarks>
+	public string CheckId { get; }
+
+	/// <summary>
+	/// Gets or sets the scope of the code that is relevant for the attribute.
+	/// </summary>
+	/// <remarks>
+	/// The Scope property is an optional argument that specifies the metadata scope for which
+	/// the attribute is relevant.
+	/// </remarks>
+	public string? Scope { get; set; }
+
+	/// <summary>
+	/// Gets or sets a fully qualified path that represents the target of the attribute.
+	/// </summary>
+	/// <remarks>
+	/// The <see cref="Target"/> property is an optional argument identifying the analysis target
+	/// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+	/// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+	/// The analysis tool user interface should be capable of automatically formatting the parameter.
+	/// </remarks>
+	public string? Target { get; set; }
+
+	/// <summary>
+	/// Gets or sets an optional argument expanding on exclusion criteria.
+	/// </summary>
+	/// <remarks>
+	/// The <see cref="MessageId "/> property is an optional argument that specifies additional
+	/// exclusion where the literal metadata target is not sufficiently precise. For example,
+	/// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+	/// and it may be desirable to suppress a violation against a statement in the method that will
+	/// give a rule violation, but not against all statements in the method.
+	/// </remarks>
+	public string? MessageId { get; set; }
+
+	/// <summary>
+	/// Gets or sets the justification for suppressing the code analysis message.
+	/// </summary>
+	public string? Justification { get; set; }
+}
+
+[AttributeUsage(
+		AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+		AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+		AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+		Inherited = false)]
+internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+	/// with the specified member types.
+	/// </summary>
+	/// <param name="memberTypes">The types of members dynamically accessed.</param>
+	public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+	{
+		MemberTypes = memberTypes;
+	}
+
+	/// <summary>
+	/// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+	/// of members dynamically accessed.
+	/// </summary>
+	public DynamicallyAccessedMemberTypes MemberTypes { get; }
+}
+
+/// <summary>
+/// Specifies the types of members that are dynamically accessed.
+///
+/// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+/// bitwise combination of its member values.
+/// </summary>
+[Flags]
+internal enum DynamicallyAccessedMemberTypes
+{
+	/// <summary>
+	/// Specifies no members.
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// Specifies the default, parameterless public constructor.
+	/// </summary>
+	PublicParameterlessConstructor = 0x0001,
+
+	/// <summary>
+	/// Specifies all public constructors.
+	/// </summary>
+	PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+	/// <summary>
+	/// Specifies all non-public constructors.
+	/// </summary>
+	NonPublicConstructors = 0x0004,
+
+	/// <summary>
+	/// Specifies all public methods.
+	/// </summary>
+	PublicMethods = 0x0008,
+
+	/// <summary>
+	/// Specifies all non-public methods.
+	/// </summary>
+	NonPublicMethods = 0x0010,
+
+	/// <summary>
+	/// Specifies all public fields.
+	/// </summary>
+	PublicFields = 0x0020,
+
+	/// <summary>
+	/// Specifies all non-public fields.
+	/// </summary>
+	NonPublicFields = 0x0040,
+
+	/// <summary>
+	/// Specifies all public nested types.
+	/// </summary>
+	PublicNestedTypes = 0x0080,
+
+	/// <summary>
+	/// Specifies all non-public nested types.
+	/// </summary>
+	NonPublicNestedTypes = 0x0100,
+
+	/// <summary>
+	/// Specifies all public properties.
+	/// </summary>
+	PublicProperties = 0x0200,
+
+	/// <summary>
+	/// Specifies all non-public properties.
+	/// </summary>
+	NonPublicProperties = 0x0400,
+
+	/// <summary>
+	/// Specifies all public events.
+	/// </summary>
+	PublicEvents = 0x0800,
+
+	/// <summary>
+	/// Specifies all non-public events.
+	/// </summary>
+	NonPublicEvents = 0x1000,
+
+	/// <summary>
+	/// Specifies all interfaces implemented by the type.
+	/// </summary>
+	Interfaces = 0x2000,
+
+	/// <summary>
+	/// Specifies all members.
+	/// </summary>
+	All = ~None
+}

--- a/src/Diagnostics.HealthChecks/Internal/ValueStopwatch.cs
+++ b/src/Diagnostics.HealthChecks/Internal/ValueStopwatch.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE1006 // ASP.NET Core codebase naming convention
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+internal struct ValueStopwatch
+{
+    private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+    private readonly long _startTimestamp;
+
+    public bool IsActive => _startTimestamp != 0;
+
+    private ValueStopwatch(long startTimestamp)
+    {
+        _startTimestamp = startTimestamp;
+    }
+
+    public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+    public TimeSpan GetElapsedTime()
+    {
+        // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+        // So it being 0 is a clear indication of default(ValueStopwatch)
+        if (!IsActive)
+        {
+            throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+        }
+
+        var end = Stopwatch.GetTimestamp();
+        var timestampDelta = end - _startTimestamp;
+        var ticks = (long)(TimestampToTicks * timestampDelta);
+        return new TimeSpan(ticks);
+    }
+}

--- a/src/Diagnostics.HealthChecks/OmexHealthCheckPublisherHostedService.cs
+++ b/src/Diagnostics.HealthChecks/OmexHealthCheckPublisherHostedService.cs
@@ -1,0 +1,351 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE1006 // ASP.NET Core codebase naming convention
+#pragma warning disable IDE0008 // Use explicit type
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+internal sealed partial class OmexHealthCheckPublisherHostedService : IHostedService
+{
+	private readonly HealthCheckService _healthCheckService;
+	private readonly IOptions<HealthCheckServiceOptions> _healthCheckServiceOptions;
+    private readonly IOptions<HealthCheckPublisherOptions> _healthCheckPublisherOptions;
+    private readonly IOptions<HealthCheckRegistrationParametersOptions> _healthCheckRegistrationOptions;
+    private readonly ILogger _logger;
+    private readonly IHealthCheckPublisher[] _publishers;
+    private readonly HealthCheckRegistrationParameters _defaultHealthCheckOptions;
+    private readonly Dictionary<HealthCheckRegistrationParameters, List<HealthCheckRegistration>> _healthChecksByOptions;
+    private Dictionary<HealthCheckRegistrationParameters, Timer>? _timersByOptions;
+
+    private readonly CancellationTokenSource _stopping;
+    private CancellationTokenSource? _runTokenSource;
+
+    public OmexHealthCheckPublisherHostedService(
+        HealthCheckService healthCheckService,
+        IOptions<HealthCheckServiceOptions> healthCheckServiceOptions,
+        IOptions<HealthCheckPublisherOptions> healthCheckPublisherOptions,
+        IOptions<HealthCheckRegistrationParametersOptions> healthCheckRegistrationOptions,
+        ILogger<OmexHealthCheckPublisherHostedService> logger,
+        IEnumerable<IHealthCheckPublisher> publishers)
+    {
+        if (healthCheckService == null)
+        {
+            throw new ArgumentNullException(nameof(healthCheckService));
+        }
+
+        if (healthCheckServiceOptions == null)
+        {
+            throw new ArgumentNullException(nameof(healthCheckServiceOptions));
+        }
+
+        if (healthCheckPublisherOptions == null)
+        {
+            throw new ArgumentNullException(nameof(healthCheckPublisherOptions));
+        }
+		
+        if (healthCheckRegistrationOptions == null)
+        {
+            throw new ArgumentNullException(nameof(healthCheckRegistrationOptions));
+        }
+
+        if (logger == null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (publishers == null)
+        {
+            throw new ArgumentNullException(nameof(publishers));
+        }
+
+        _healthCheckService = healthCheckService;
+        _healthCheckServiceOptions = healthCheckServiceOptions;
+        _healthCheckPublisherOptions = healthCheckPublisherOptions;
+		_healthCheckRegistrationOptions = healthCheckRegistrationOptions;
+        _logger = logger;
+        _publishers = publishers.ToArray();
+
+        _stopping = new CancellationTokenSource();
+
+        // We're specifically going out of our way to do this at startup time. We want to make sure you
+        // get any kind of health-check related error as early as possible. Waiting until someone
+        // actually tries to **run** health checks would be real baaaaad.
+        ValidateRegistrations(_healthCheckServiceOptions.Value.Registrations);
+
+        _defaultHealthCheckOptions = new HealthCheckRegistrationParameters(_healthCheckPublisherOptions.Value.Delay, _healthCheckPublisherOptions.Value.Period);
+        // Group healthcheck registrations by delay and period, to build a Dictionary<(TimeSpan, TimeSpan), List<HealthCheckRegistration>>
+        // For HCs with no Delay or Period, we default to the publisher values
+        _healthChecksByOptions = (from r in _healthCheckServiceOptions.Value.Registrations
+                                  group r by GetHealthCheckRegistrationParametersOrDefault(r.Name) ?? _defaultHealthCheckOptions).ToDictionary(g => g.Key, g => g.ToList());
+    }
+
+	private HealthCheckRegistrationParameters? GetHealthCheckRegistrationParametersOrDefault(string registrationName)
+	{
+		_healthCheckRegistrationOptions.Value.RegistrationParameters.TryGetValue(registrationName, out var registrationParameters);
+
+		return registrationParameters;
+	}
+
+	internal bool IsStopping => _stopping.IsCancellationRequested;
+
+    internal bool IsTimerRunning => _timersByOptions != null;
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_publishers.Length == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        // IMPORTANT - make sure this is the last thing that happens in this method. The timer can
+        // fire before other code runs.
+        _timersByOptions = CreateTimers(_healthChecksByOptions);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _stopping.Cancel();
+        }
+        catch
+        {
+            // Ignore exceptions thrown as a result of a cancellation.
+        }
+
+        if (_publishers.Length == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (_timersByOptions != null)
+        {
+            foreach (var timer in _timersByOptions.Values)
+            {
+                timer.Dispose();
+            }
+
+            _timersByOptions = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Dictionary<HealthCheckRegistrationParameters, Timer> CreateTimers(IReadOnlyDictionary<HealthCheckRegistrationParameters, List<HealthCheckRegistration>> periodHealthChecksMap)
+    {
+        return periodHealthChecksMap.Select(m => CreateTimer(m.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    private KeyValuePair<HealthCheckRegistrationParameters, Timer> CreateTimer(HealthCheckRegistrationParameters healthCheckOptions)
+    {
+        return new KeyValuePair<HealthCheckRegistrationParameters, Timer>(
+            healthCheckOptions,
+            NonCapturingTimer.Create(
+            async (state) =>
+            {
+                await RunAsync(healthCheckOptions: healthCheckOptions).ConfigureAwait(false);
+            },
+            null,
+            dueTime: healthCheckOptions.Delay ?? _healthCheckPublisherOptions.Value.Delay, // Default to publisher Delay
+            period: healthCheckOptions.Period ?? _healthCheckPublisherOptions.Value.Period) // Default to publisher Period
+        );
+    }
+
+    // Internal for testing
+    internal void CancelToken()
+    {
+        _runTokenSource!.Cancel();
+    }
+
+    // Internal for testing
+    internal async Task RunAsync(HealthCheckRegistrationParameters? healthCheckOptions = default)
+    {
+        if (healthCheckOptions == default)
+        {
+            healthCheckOptions = _defaultHealthCheckOptions;
+        }
+
+        var duration = ValueStopwatch.StartNew();
+        Logger.HealthCheckPublisherProcessingBegin(_logger);
+
+        CancellationTokenSource? cancellation = null;
+        try
+        {
+            var timeout = healthCheckOptions.Timeout ?? _healthCheckPublisherOptions.Value.Timeout;
+
+            cancellation = CancellationTokenSource.CreateLinkedTokenSource(_stopping.Token);
+            _runTokenSource = cancellation;
+            cancellation.CancelAfter(timeout);
+
+            await RunAsyncCore(healthCheckOptions, cancellation.Token).ConfigureAwait(false);
+
+            Logger.HealthCheckPublisherProcessingEnd(_logger, duration.GetElapsedTime());
+        }
+        catch (OperationCanceledException) when (IsStopping)
+        {
+            // This is a cancellation - if the app is shutting down we want to ignore it. Otherwise, it's
+            // a timeout and we want to log it.
+        }
+        catch (Exception ex)
+        {
+            // This is an error, publishing failed.
+            Logger.HealthCheckPublisherProcessingEnd(_logger, duration.GetElapsedTime(), ex);
+        }
+        finally
+        {
+            cancellation?.Dispose();
+        }
+    }
+
+    private async Task RunAsyncCore(HealthCheckRegistrationParameters healthCheckOptions, CancellationToken cancellationToken)
+    {
+        // Forcibly yield - we want to unblock the timer thread.
+        await Task.Yield();
+
+        // Concatenate predicates - we only run HCs with the set delay and period
+        var withOptionsPredicate = (HealthCheckRegistration r) =>
+        {
+			var options = GetHealthCheckRegistrationParametersOrDefault(r.Name);
+            var hasOptions = (options == default && healthCheckOptions == _defaultHealthCheckOptions) ||
+                              options == healthCheckOptions;
+            if (_healthCheckPublisherOptions?.Value.Predicate == null)
+            {
+                return hasOptions;
+            }
+
+            return hasOptions && _healthCheckPublisherOptions.Value.Predicate(r);
+        };
+
+        // The health checks service does it's own logging, and doesn't throw exceptions.
+        var report = await _healthCheckService.CheckHealthAsync(withOptionsPredicate, cancellationToken).ConfigureAwait(false);
+
+        var publishers = _publishers;
+        var tasks = new Task[publishers.Length];
+        for (var i = 0; i < publishers.Length; i++)
+        {
+            tasks[i] = RunPublisherAsync(publishers[i], report, cancellationToken);
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private async Task RunPublisherAsync(IHealthCheckPublisher publisher, HealthReport report, CancellationToken cancellationToken)
+    {
+        var duration = ValueStopwatch.StartNew();
+
+        try
+        {
+            Logger.HealthCheckPublisherBegin(_logger, publisher);
+
+            await publisher.PublishAsync(report, cancellationToken).ConfigureAwait(false);
+            Logger.HealthCheckPublisherEnd(_logger, publisher, duration.GetElapsedTime());
+        }
+        catch (OperationCanceledException) when (IsStopping)
+        {
+            // This is a cancellation - if the app is shutting down we want to ignore it. Otherwise, it's
+            // a timeout and we want to log it.
+        }
+        catch (OperationCanceledException)
+        {
+            Logger.HealthCheckPublisherTimeout(_logger, publisher, duration.GetElapsedTime());
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.HealthCheckPublisherError(_logger, publisher, duration.GetElapsedTime(), ex);
+            throw;
+        }
+    }
+
+    private static void ValidateRegistrations(IEnumerable<HealthCheckRegistration> registrations)
+    {
+        // Scan the list for duplicate names to provide a better error if there are duplicates.
+
+        StringBuilder? builder = null;
+        var distinctRegistrations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var registration in registrations)
+        {
+            if (!distinctRegistrations.Add(registration.Name))
+            {
+                builder ??= new StringBuilder("Duplicate health checks were registered with the name(s): ");
+
+                builder.Append(registration.Name).Append(", ");
+            }
+        }
+
+        if (builder is not null)
+        {
+            throw new ArgumentException(builder.ToString(0, builder.Length - 2), nameof(registrations));
+        }
+    }
+
+    internal static class EventIds
+    {
+        public const int HealthCheckPublisherProcessingBeginId = 100;
+        public const int HealthCheckPublisherProcessingEndId = 101;
+        public const int HealthCheckPublisherBeginId = 102;
+        public const int HealthCheckPublisherEndId = 103;
+        public const int HealthCheckPublisherErrorId = 104;
+        public const int HealthCheckPublisherTimeoutId = 104;
+
+        // Hard code the event names to avoid breaking changes. Even if the methods are renamed, these hard-coded names shouldn't change.
+        public const string HealthCheckPublisherProcessingBeginName = "HealthCheckPublisherProcessingBegin";
+        public const string HealthCheckPublisherProcessingEndName = "HealthCheckPublisherProcessingEnd";
+        public const string HealthCheckPublisherBeginName = "HealthCheckPublisherBegin";
+        public const string HealthCheckPublisherEndName = "HealthCheckPublisherEnd";
+        public const string HealthCheckPublisherErrorName = "HealthCheckPublisherError";
+        public const string HealthCheckPublisherTimeoutName = "HealthCheckPublisherTimeout";
+    }
+
+    private static partial class Logger
+    {
+        [LoggerMessage(EventIds.HealthCheckPublisherProcessingBeginId, LogLevel.Debug, "Running health check publishers", EventName = EventIds.HealthCheckPublisherProcessingBeginName)]
+        public static partial void HealthCheckPublisherProcessingBegin(ILogger logger);
+
+        public static void HealthCheckPublisherProcessingEnd(ILogger logger, TimeSpan duration, Exception? exception = null) =>
+            HealthCheckPublisherProcessingEnd(logger, duration.TotalMilliseconds, exception);
+
+        [LoggerMessage(EventIds.HealthCheckPublisherProcessingEndId, LogLevel.Debug, "Health check publisher processing completed after {ElapsedMilliseconds}ms", EventName = EventIds.HealthCheckPublisherProcessingEndName)]
+        private static partial void HealthCheckPublisherProcessingEnd(ILogger logger, double ElapsedMilliseconds, Exception? exception = null);
+
+        [LoggerMessage(EventIds.HealthCheckPublisherBeginId, LogLevel.Debug, "Running health check publisher '{HealthCheckPublisher}'", EventName = EventIds.HealthCheckPublisherBeginName)]
+        public static partial void HealthCheckPublisherBegin(ILogger logger, IHealthCheckPublisher HealthCheckPublisher);
+
+        public static void HealthCheckPublisherEnd(ILogger logger, IHealthCheckPublisher HealthCheckPublisher, TimeSpan duration) =>
+            HealthCheckPublisherEnd(logger, HealthCheckPublisher, duration.TotalMilliseconds);
+
+        [LoggerMessage(EventIds.HealthCheckPublisherEndId, LogLevel.Debug, "Health check '{HealthCheckPublisher}' completed after {ElapsedMilliseconds}ms", EventName = EventIds.HealthCheckPublisherEndName)]
+        private static partial void HealthCheckPublisherEnd(ILogger logger, IHealthCheckPublisher HealthCheckPublisher, double ElapsedMilliseconds);
+
+        public static void HealthCheckPublisherError(ILogger logger, IHealthCheckPublisher publisher, TimeSpan duration, Exception exception) =>
+            HealthCheckPublisherError(logger, publisher, duration.TotalMilliseconds, exception);
+
+#pragma warning disable SYSLIB1006
+        [LoggerMessage(EventIds.HealthCheckPublisherErrorId, LogLevel.Error, "Health check {HealthCheckPublisher} threw an unhandled exception after {ElapsedMilliseconds}ms", EventName = EventIds.HealthCheckPublisherErrorName)]
+        private static partial void HealthCheckPublisherError(ILogger logger, IHealthCheckPublisher HealthCheckPublisher, double ElapsedMilliseconds, Exception exception);
+
+        public static void HealthCheckPublisherTimeout(ILogger logger, IHealthCheckPublisher publisher, TimeSpan duration) =>
+            HealthCheckPublisherTimeout(logger, publisher, duration.TotalMilliseconds);
+
+        [LoggerMessage(EventIds.HealthCheckPublisherTimeoutId, LogLevel.Error, "Health check {HealthCheckPublisher} was canceled after {ElapsedMilliseconds}ms", EventName = EventIds.HealthCheckPublisherTimeoutName)]
+        private static partial void HealthCheckPublisherTimeout(ILogger logger, IHealthCheckPublisher HealthCheckPublisher, double ElapsedMilliseconds);
+#pragma warning restore SYSLIB1006
+    }
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/Extensions/TaskExtensions.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Extensions/TaskExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// Imported from https://github.com/dotnet/aspnetcore/blob/main/src/Shared/TaskExtensions.cs
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Extensions
+{
+	public static class TaskExtensions
+	{
+		public static string CreateMessage(TimeSpan timeout, string filePath, int lineNumber)
+		=> string.IsNullOrEmpty(filePath)
+		? $"The operation timed out after reaching the limit of {timeout.TotalMilliseconds}ms."
+		: $"The operation at {filePath}:{lineNumber} timed out after reaching the limit of {timeout.TotalMilliseconds}ms.";
+
+		public static async Task TimeoutAfter(this Task task, TimeSpan timeout,
+			[CallerFilePath] string filePath = "",
+			[CallerLineNumber] int lineNumber = default)
+		{
+			// Don't create a timer if the task is already completed
+			// or the debugger is attached
+			if (task.IsCompleted || Debugger.IsAttached)
+			{
+				await task.ConfigureAwait(false);
+				return;
+			}
+#if NET6_0_OR_GREATER
+			try
+			{
+				await task.WaitAsync(timeout).ConfigureAwait(false);
+			}
+			catch (TimeoutException ex) when (ex.Source == typeof(TaskExtensions).Namespace)
+			{
+				throw new TimeoutException(CreateMessage(timeout, filePath, lineNumber));
+			}
+#else
+			var cts = new CancellationTokenSource();
+			if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
+			{
+				cts.Cancel();
+				await task.ConfigureAwait(false);
+			}
+			else
+			{
+				throw new TimeoutException(CreateMessage(timeout, filePath, lineNumber));
+			}
+#endif
+		}
+	}
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/OmexHealthCheckPublisherHostedServiceTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/OmexHealthCheckPublisherHostedServiceTests.cs
@@ -1,0 +1,640 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// Unit tests extended from: https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/HealthChecks/test/HealthCheckPublisherHostedServiceTest.cs
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Omex.Extensions.DependencyInjection;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Extensions;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
+{
+	[TestClass]
+	public class OmexHealthCheckPublisherHostedServiceTest
+	{
+		[TestMethod]
+		public async Task StartAsync_WithoutPublishers_DoesNotStartTimer()
+		{
+			// Arrange
+			IHealthCheckPublisher[] publishers = Array.Empty<IHealthCheckPublisher>();
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers);
+
+			try
+			{
+				// Act
+				await service.StartAsync();
+
+				// Assert
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task StartAsync_WithPublishers_StartsTimer()
+		{
+			// Arrange
+			IHealthCheckPublisher[]? publishers = new IHealthCheckPublisher[]
+			{
+				new TestPublisher(),
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers);
+
+			try
+			{
+				// Act
+				await service.StartAsync();
+
+				// Assert
+				Assert.IsFalse(service.IsStopping);
+				Assert.IsTrue(service.IsTimerRunning);
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task StartAsync_WithPublishers_StartsTimer_RunsPublishers()
+		{
+			// Arrange
+			TaskCompletionSource<object?> unblock0 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<object?> unblock1 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<object?> unblock2 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock0.Task, },
+				new TestPublisher() { Wait = unblock1.Task, },
+				new TestPublisher() { Wait = unblock2.Task, },
+			};
+
+			OmexHealthCheckPublisherHostedService? service = CreateService(publishers, configurePublisherOptions: (options) =>
+			{
+				options.Delay = TimeSpan.FromMilliseconds(0);
+			});
+
+			try
+			{
+				// Act
+				await service.StartAsync();
+
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+				await publishers[1].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+				await publishers[2].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				unblock0.SetResult(null);
+				unblock1.SetResult(null);
+				unblock2.SetResult(null);
+
+				// Assert
+				Assert.IsTrue(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task StopAsync_CancelsExecution()
+		{
+			// Arrange
+			TaskCompletionSource<object?> unblock = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock.Task, }
+			};
+
+			OmexHealthCheckPublisherHostedService? service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Start execution
+				Task? running = service.RunAsync();
+
+				// Wait for the publisher to see the cancellation token
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+				Assert.IsTrue(publishers[0].Entries.Count == 1);
+
+				// Act
+				await service.StopAsync(); // Trigger cancellation
+
+				// Assert
+				await AssertCanceledAsync(publishers[0].Entries[0].cancellationToken);
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+
+				unblock.SetResult(null);
+
+				await running.TimeoutAfter(TimeSpan.FromSeconds(10));
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_WaitsForCompletion_Single()
+		{
+			// Arrange
+			TaskCompletionSource<object?> unblock = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock.Task, },
+			};
+
+			OmexHealthCheckPublisherHostedService? service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				Task running = service.RunAsync();
+
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				unblock.SetResult(null);
+
+				await running.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				// Assert
+				Assert.IsTrue(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					Assert.IsTrue(publishers[i].Entries.Count == 1);
+					HealthReport report = publishers[i].Entries.Single().report;
+					CollectionAssert.AreEqual(new[] { "one", "two", }, report.Entries.Keys.OrderBy(k => k).ToArray());
+				}
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_WaitsForCompletion_Single_RegistrationParameters()
+		{
+			// Arrange
+			const string HealthyMessage = "Everything is A-OK";
+
+			TaskCompletionSource<object?> unblock = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<object?> unblockDelayedCheck = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock.Task, },
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers, configureBuilder: b => {
+				b.AddAsyncCheck("CheckDefault", _ =>
+					{
+						return Task.FromResult(HealthCheckResult.Healthy(HealthyMessage));
+					});
+
+				b.AddAsyncCheck("CheckDelay2Period18", _ =>
+					{
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
+
+				b.AddAsyncCheck("CheckDelay7Period11", _ =>
+					{
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
+
+				b.AddAsyncCheck("CheckDelay9Period5", _ =>
+					{
+						unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+			});
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				Task running = service.RunAsync();
+
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				unblock.SetResult(null);
+
+				await running.TimeoutAfter(TimeSpan.FromSeconds(20));
+
+				await Task.WhenAll(unblock.Task, unblockDelayedCheck.Task);
+
+				// Assert
+				Assert.IsTrue(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					Assert.IsTrue(publishers[i].Entries.Count == 4);
+					string[] entries = publishers[i].Entries.SelectMany(e => e.report.Entries.Select(e2 => e2.Key)).OrderBy(k => k).ToArray();
+					CollectionAssert.AreEqual(
+						new[] { "CheckDefault", "CheckDelay2Period18", "CheckDelay7Period11", "CheckDelay9Period5" },
+						entries);
+				}
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_WaitsForCompletion_Multiple()
+		{
+			// Arrange
+			TaskCompletionSource<object?> unblock0 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<object?> unblock1 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<object?> unblock2 = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock0.Task, },
+				new TestPublisher() { Wait = unblock1.Task, },
+				new TestPublisher() { Wait = unblock2.Task, },
+			};
+
+			OmexHealthCheckPublisherHostedService? service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				Task running = service.RunAsync();
+
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+				await publishers[1].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+				await publishers[2].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				unblock0.SetResult(null);
+				unblock1.SetResult(null);
+				unblock2.SetResult(null);
+
+				await running.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				// Assert
+				Assert.IsTrue(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					Assert.IsTrue(publishers[i].Entries.Count == 1);
+					HealthReport report = publishers[i].Entries.Single().report;
+					CollectionAssert.AreEqual(new[] { "one", "two", }, report.Entries.Keys.OrderBy(k => k).ToArray());
+				}
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_PublishersCanTimeout()
+		{
+			// Arrange
+			TaskCompletionSource<object?> unblock = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Wait = unblock.Task, },
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				Task running = service.RunAsync();
+
+				await publishers[0].Started.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				service.CancelToken();
+
+				await AssertCanceledAsync(publishers[0].Entries[0].cancellationToken);
+
+				unblock.SetResult(null);
+
+				await running.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				// Assert
+				Assert.IsTrue(service.IsTimerRunning);
+				Assert.IsFalse(service.IsStopping);
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_CanFilterHealthChecks()
+		{
+			// Arrange
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher(),
+				new TestPublisher(),
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers, configurePublisherOptions: (options) =>
+			{
+				options.Predicate = (r) => r.Name == "one";
+			});
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				await service.RunAsync().TimeoutAfter(TimeSpan.FromSeconds(10));
+
+				// Assert
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					Assert.IsTrue(publishers[i].Entries.Count == 1);
+					HealthReport report = publishers[i].Entries.Single().report;
+					CollectionAssert.AreEqual(new[] { "one" }, report.Entries.Keys.OrderBy(k => k).ToArray());
+				}
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_CanFilterHealthChecks_RegistrationParameters()
+		{
+			// Arrange
+			const string HealthyMessage = "Everything is A-OK";
+
+			TaskCompletionSource<object?> unblockDelayedCheck = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher(),
+				new TestPublisher(),
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(
+				publishers,
+				configurePublisherOptions: (options) =>
+				{
+					options.Predicate = (r) => r.Name.Contains("Delay");
+				},
+				configureBuilder: b =>
+				{
+					b.AddAsyncCheck("CheckDefault", _ =>
+					{
+						return Task.FromResult(HealthCheckResult.Healthy(HealthyMessage));
+					});
+
+					b.AddAsyncCheck("CheckDelay2Period18", _ =>
+					{
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
+
+					b.AddAsyncCheck("CheckDelay7Period11", _ =>
+					{
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
+
+					b.AddAsyncCheck("CheckDelay9Period5", _ =>
+					{
+						unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+				});
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				await service.RunAsync().TimeoutAfter(TimeSpan.FromSeconds(20));
+
+				await unblockDelayedCheck.Task;
+
+				// Assert
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					string[] entries = publishers[i].Entries.SelectMany(e => e.report.Entries.Select(e2 => e2.Key)).OrderBy(k => k).ToArray();
+
+					Assert.IsTrue(entries.Count() == 3);
+					CollectionAssert.AreEqual(
+						new[] { "CheckDelay2Period18", "CheckDelay7Period11", "CheckDelay9Period5" },
+						entries);
+				}
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_HandlesExceptions()
+		{
+			// Arrange
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Exception = new InvalidTimeZoneException(), },
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				await service.RunAsync().TimeoutAfter(TimeSpan.FromSeconds(10));
+
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		[TestMethod]
+		public async Task RunAsync_HandlesExceptions_Multiple()
+		{
+			// Arrange
+			TestPublisher[] publishers = new TestPublisher[]
+			{
+				new TestPublisher() { Exception = new InvalidTimeZoneException(), },
+				new TestPublisher(),
+				new TestPublisher() { Exception = new InvalidTimeZoneException(), },
+			};
+
+			OmexHealthCheckPublisherHostedService service = CreateService(publishers);
+
+			try
+			{
+				await service.StartAsync();
+
+				// Act
+				await service.RunAsync().TimeoutAfter(TimeSpan.FromSeconds(10));
+
+			}
+			finally
+			{
+				await service.StopAsync();
+				Assert.IsFalse(service.IsTimerRunning);
+				Assert.IsTrue(service.IsStopping);
+			}
+		}
+
+		private OmexHealthCheckPublisherHostedService CreateService(
+			IHealthCheckPublisher[] publishers,
+			Action<HealthCheckPublisherOptions>? configurePublisherOptions = null,
+			Action<IOmexHealthChecksBuilder>? configureBuilder = null)
+		{
+			ServiceCollection serviceCollection = new();
+			serviceCollection.AddOptions();
+			serviceCollection.AddLogging();
+			IOmexHealthChecksBuilder builder = serviceCollection.AddOmexHealthChecks();
+			if (configureBuilder == null)
+			{
+				// Default builder configuration
+				builder.AddAsyncCheck("one", () => new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy()))
+					   .AddAsyncCheck("two", () => new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy()));
+			}
+			else
+			{
+				configureBuilder(builder);
+			}
+
+			// Choosing big values for tests to make sure that we're not dependent on the defaults.
+			// All of the tests that rely on the timer will set their own values for speed.
+			serviceCollection.Configure<HealthCheckPublisherOptions>(options =>
+			{
+				options.Delay = TimeSpan.FromMinutes(5);
+				options.Period = TimeSpan.FromMinutes(5);
+				options.Timeout = TimeSpan.FromMinutes(5);
+			});
+
+			if (publishers != null)
+			{
+				for (int i = 0; i < publishers.Length; i++)
+				{
+					serviceCollection.AddSingleton<IHealthCheckPublisher>(publishers[i]);
+				}
+			}
+
+			if (configurePublisherOptions != null)
+			{
+				serviceCollection.Configure(configurePublisherOptions);
+			}
+
+			ServiceProvider? services = serviceCollection.BuildServiceProvider();
+			return services.GetServices<IHostedService>().OfType<OmexHealthCheckPublisherHostedService>().Single();
+		}
+
+		private static async Task AssertCanceledAsync(CancellationToken cancellationToken)
+		{
+			await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => Task.Delay(TimeSpan.FromSeconds(10), cancellationToken));
+		}
+
+		private class TestPublisher : IHealthCheckPublisher
+		{
+			private readonly TaskCompletionSource<object?> m_started;
+
+			public TestPublisher()
+			{
+				m_started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			}
+
+			public List<(HealthReport report, CancellationToken cancellationToken)> Entries { get; } = new List<(HealthReport report, CancellationToken cancellationToken)>();
+
+			public Exception? Exception { get; set; }
+
+			public Task Started => m_started.Task;
+
+			public Task? Wait { get; set; }
+
+			public async Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+			{
+				Entries.Add((report, cancellationToken));
+
+				// Signal that we've started
+				m_started.TrySetResult(null);
+
+				if (Wait != null)
+				{
+					await Wait;
+				}
+
+				if (Exception != null)
+				{
+					throw Exception;
+				}
+
+				cancellationToken.ThrowIfCancellationRequested();
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Introduce per-HealthCheckRegistration parameters

Change delay, periodicity and timeout on a per-Healthcheck basis. Currently all health checks share the same delay, period and timeout.

**Note**: This PR might be possibly merged as part of the ASP.NET Core codebase through [Introduce per-HealthCheck Options #42646](https://github.com/dotnet/aspnetcore/pull/42646). For this reason, we are disabling errors and warnings caused by the different coding conventions followed and rely on importing underlying internal classes used by `PublishedHostedService`.

## Description

In the current implementation, delay, periodicity and timeout options of the healthchecks are set at the `HealthCheckPublisherOptions` configuration level and shared across all `HealthCheckRegistration`.

This PR introduces per-HealthCheck delay, period and timeout (namely **Individual Healthchecks**) by extending the `HealthCheckRegistration` and `HealthCheckPublisherHostedService`.

If no Delay, Period or Timeout is specified during the `AddCheck(...)`, values from the `HealthCheckPublisherOptions` will be used instead.

The HealthCheck API layer will change for:

### OmexHealthChecksBuilderAddCheckExtensions.cs

```diff
namespace Microsoft.Omex.Extensions.DependencyInjection;

public static HealthChecksBuilderAddCheckExtensions
{
+    public static IHealthChecksBuilder AddCheck(this IHealthChecksBuilder builder, string name, Func<HealthCheckResult> check, IEnumerable<string>? tags = null, TimeSpan? timeout = default, HealthCheckRegistrationParameters? parameters= default);
+    public static IHealthChecksBuilder AddCheck<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IHealthChecksBuilder builder, string name, HealthStatus? failureStatus = null, IEnumerable<string>? tags = null, TimeSpan? timeout = null,  HealthCheckRegistrationParameters? parameters= default);
+    public static IHealthChecksBuilder AddTypeActivatedCheck<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IHealthChecksBuilder builder, string name, HealthStatus? failureStatus, IEnumerable<string> tags, TimeSpan timeout,  HealthCheckRegistrationParameters? parameters, params object[] args);
}
```

### OmexHealthChecksBuilderDelegateExtensions.cs

```diff
namespace Microsoft.Omex.Extensions.DependencyInjection;

public static HealthChecksBuilderDelegateExtensions
{
+    public static IHealthChecksBuilder AddCheck(this IHealthChecksBuilder builder, string name, Func<HealthCheckResult> check, IEnumerable<string>? tags = null, TimeSpan? timeout = default, HealthCheckRegistrationParameters? parameters= default);
+    public static IHealthChecksBuilder AddCheck(this IHealthChecksBuilder builder, string name, Func<CancellationToken, HealthCheckResult> check, IEnumerable<string>? tags = null, TimeSpan? timeout = default,  HealthCheckRegistrationParameters? parameters= default);
+    public static IHealthChecksBuilder AddAsyncCheck(this IHealthChecksBuilder builder, string name, Func<Task<HealthCheckResult>> check, IEnumerable<string>? tags = null, TimeSpan? timeout = default,  HealthCheckRegistrationParameters? parameters= default);
+    public static IHealthChecksBuilder AddAsyncCheck(this IHealthChecksBuilder builder, string name, Func<CancellationToken, Task<HealthCheckResult>> check, IEnumerable<string>? tags = null, TimeSpan? timeout = default,  HealthCheckRegistrationParameters? parameters= default);
}
```

Here is an example on how to use the modified `OmexHealthChecksBuilder`:

```csharp
builder.Services.AddOmexHealthChecks()
    .AddCheck("SampleHealthCheck1", parameters: new(delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18))
    .AddCheck<SampleHealthCheck2>("SampleHealthCheck2", parameters: new(delay: TimeSpan.FromSeconds(20), period: TimeSpan.FromSeconds(3))
    .AddTypeActivatedCheck<SampleHealthCheckWithArgs>(
        "SampleHealthCheck3",
        failureStatus: HealthStatus.Degraded,
        tags: new[] { "SampleHealthCheck3" },
        args: new object[] { 1, "Arg" },
        parameters: new(delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(12))
);
```