### PR TITLE
Moving Service Fabric to 9CU2

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -38,12 +38,12 @@
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Label="ServiceFabric packages for Omex Extensions">
-    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1028" />
+    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1048" />
     <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.7.1" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1028" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1028" />
-    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1028" />
-    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1028" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.1" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1048" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Details on changes here, including Windows Server 2022 support:
https://techcommunity.microsoft.com/t5/azure-service-fabric-blog/microsoft-azure-service-fabric-9-0-second-refresh-release/ba-p/3575842