### PR TITLE
Replace inefficient uses of Process

### DIFF
--- a/src/Logging/InitializationLogger.cs
+++ b/src/Logging/InitializationLogger.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Omex.Extensions.Logging
 		public static void LogInitializationSucceed(string serviceNameForLogging, string message = "")
 		{
 			string logMessage = $"Initialization successful for {serviceNameForLogging}, {message}";
-#if Net_Standard
+#if NET5_0_OR_GREATER
+			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(Environment.ProcessId, serviceNameForLogging, logMessage);
+#else
 			using Process process = Process.GetCurrentProcess();
 			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(process.Id, serviceNameForLogging, logMessage);
-#else
-			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(Environment.ProcessId, serviceNameForLogging, logMessage);
 #endif
 			Instance.LogInformation(Tag.Create(), logMessage);
 		}

--- a/src/Logging/InitializationLogger.cs
+++ b/src/Logging/InitializationLogger.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		public static void LogInitializationSucceed(string serviceNameForLogging, string message = "")
 		{
 			string logMessage = $"Initialization successful for {serviceNameForLogging}, {message}";
-			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(Process.GetCurrentProcess().Id, serviceNameForLogging, logMessage);
+			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(Environment.ProcessId, serviceNameForLogging, logMessage);
 			Instance.LogInformation(Tag.Create(), logMessage);
 		}
 

--- a/src/Logging/InitializationLogger.cs
+++ b/src/Logging/InitializationLogger.cs
@@ -41,7 +41,12 @@ namespace Microsoft.Omex.Extensions.Logging
 		public static void LogInitializationSucceed(string serviceNameForLogging, string message = "")
 		{
 			string logMessage = $"Initialization successful for {serviceNameForLogging}, {message}";
+#if Net_Standard
+			using Process process = Process.GetCurrentProcess();
+			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(process.Id, serviceNameForLogging, logMessage);
+#else
 			ServiceInitializationEventSource.Instance.LogHostBuildSucceeded(Environment.ProcessId, serviceNameForLogging, logMessage);
+#endif
 			Instance.LogInformation(Tag.Create(), logMessage);
 		}
 

--- a/src/Logging/Internal/EventSource/OmexLogEventSender.cs
+++ b/src/Logging/Internal/EventSource/OmexLogEventSender.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Omex.Extensions.Logging
 	{
 		static OmexLogEventSender()
 		{
-			Process process = Process.GetCurrentProcess();
+			using Process process = Process.GetCurrentProcess();
 			s_processName = string.Format(CultureInfo.InvariantCulture, "{0} (0x{1:X4})", process.ProcessName, process.Id);
 		}
 

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
+    <DefineConstants>$(DefineConstants);Net_Standard</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Logging</Title>
     <Summary>Microsoft Omex Extensions Logging</Summary>

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
-    <DefineConstants>$(DefineConstants);Net_Standard</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Logging</Title>
     <Summary>Microsoft Omex Extensions Logging</Summary>


### PR DESCRIPTION
In some logging classes Process.GetCurrentProcess is used incorrectly.
This change fixes these use cases.

- Replace Process.GetCurrentProcess.Id in initialization logger, with Environment.ProcessId to prevent unnecessary Process initialization. (https://docs.microsoft.com/en-us/dotnet/api/system.environment.processid?view=net-6.0).
- Add using scope around Process in OmexLogEventSender to ensure it is disposed correctly.

Fixes https://github.com/microsoft/Omex/issues/453