### PR TITLE
Introduce Selective HealthChecks

### DIFF
--- a/src/Diagnostics.HealthChecks/HealthCheckRegistrationParameters.cs
+++ b/src/Diagnostics.HealthChecks/HealthCheckRegistrationParameters.cs
@@ -15,26 +15,35 @@ public class HealthCheckRegistrationParameters
 	/// <summary>
 	/// Creates a new <see cref="T:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistrationParameters" />.
 	/// </summary>
+	/// <param name="name">A <see cref="string"/> indicating the name of the check.</param>
+	/// <param name="isEnabled">An optional <see cref="bool"/> indicating whether the check should be run.</param>
 	/// <param name="delay">An optional <see cref="TimeSpan"/> representing the initial delay applied after the application starts before executing the check.</param>
 	/// <param name="period">An optional <see cref="TimeSpan"/> representing the individual period of the check.</param>
 	/// <param name="timeout">An optional <see cref="TimeSpan"/> representing the individual timeout of the check.</param>
-	public HealthCheckRegistrationParameters(TimeSpan? delay = default, TimeSpan? period = default, TimeSpan? timeout = default)
+	public HealthCheckRegistrationParameters(string name, bool isEnabled = true, TimeSpan? delay = default, TimeSpan? period = default, TimeSpan? timeout = default)
 	{
+		Name = name;
+		IsEnabled = isEnabled;
 		Delay = delay;
 		Period = period;
 		Timeout = timeout;
 	}
 
 	/// <summary>
+	/// Gets the name of the health check.
+	/// </summary>
+	public string Name { get; }
+
+	/// <summary>
 	/// Gets the initial individual delay applied to the
-	/// individual HealthCheck after the application starts before executing.
+	/// individual health check after the application starts before executing.
 	/// The delay is applied once at startup, and does
 	/// not apply to subsequent iterations.
 	/// </summary>
 	public TimeSpan? Delay { get; }
 
 	/// <summary>
-	/// Gets the individual period used for the check.
+	/// Gets the individual period used for the health check.
 	/// </summary>
 	public TimeSpan? Period { get; }
 
@@ -43,4 +52,9 @@ public class HealthCheckRegistrationParameters
 	/// Use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to execute with no timeout.
 	/// </summary>
 	public TimeSpan? Timeout { get; }
+
+	/// <summary>
+	/// Gets or sets whether the health check should be run. Enabled by default.
+	/// </summary>
+	public bool IsEnabled { get; set; } = true;
 }

--- a/tests/Diagnostics.HealthChecks.UnitTests/OmexHealthCheckPublisherHostedServiceTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/OmexHealthCheckPublisherHostedServiceTests.cs
@@ -228,28 +228,35 @@ namespace Microsoft.Omex.Preview.Extensions.Diagnostics.HealthChecks.UnitTests
 			var service = CreateService(publishers, configureBuilder: b =>
 			{
 				b.AddAsyncCheck("CheckDefault", _ =>
-					{
-						return Task.FromResult(HealthCheckResult.Healthy(HealthyMessage));
-					});
+				{
+					return Task.FromResult(HealthCheckResult.Healthy(HealthyMessage));
+				});
 
 				b.AddAsyncCheck("CheckDelay2Period18", _ =>
-					{
-						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
-					},
-					parameters: new(delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
+				{
+					return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+				},
+				parameters: new(name: "CheckDelay2Period18", delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
 
 				b.AddAsyncCheck("CheckDelay7Period11", _ =>
-					{
-						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
-					},
-					parameters: new(delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
+				{
+					return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+				},
+				parameters: new(name: "CheckDelay7Period11", delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
 
 				b.AddAsyncCheck("CheckDelay9Period5", _ =>
-					{
-						unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
-						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
-					},
-					parameters: new(delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+				{
+					unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
+					return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+				},
+				parameters: new(name: "CheckDelay9Period5", delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+
+				b.AddAsyncCheck("DisabledCheck", _ =>
+				{
+					unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
+					return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+				},
+				parameters: new(name: "DisabledCheck", delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5), isEnabled: false));
 			});
 
 			try
@@ -452,20 +459,27 @@ namespace Microsoft.Omex.Preview.Extensions.Diagnostics.HealthChecks.UnitTests
 					{
 						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
 					},
-					parameters: new(delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
+					parameters: new(name: "CheckDelay2Period18", delay: TimeSpan.FromSeconds(2), period: TimeSpan.FromSeconds(18)));
 
 					b.AddAsyncCheck("CheckDelay7Period11", _ =>
 					{
 						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
 					},
-					parameters: new(delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
+					parameters: new(name: "CheckDelay7Period11", delay: TimeSpan.FromSeconds(7), period: TimeSpan.FromSeconds(11)));
 
 					b.AddAsyncCheck("CheckDelay9Period5", _ =>
 					{
 						unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
 						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
 					},
-					parameters: new(delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+					parameters: new(name: "CheckDelay9Period5", delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5)));
+
+					b.AddAsyncCheck("DisabledCheck", _ =>
+					{
+						unblockDelayedCheck.TrySetResult(null); // Unblock last delayed check
+						return new ValueTask<HealthCheckResult>(HealthCheckResult.Healthy(HealthyMessage));
+					},
+					parameters: new(name: "DisabledCheck", delay: TimeSpan.FromSeconds(9), period: TimeSpan.FromSeconds(5), isEnabled: false));
 				});
 
 			try


### PR DESCRIPTION
Adds up from: https://github.com/microsoft/Omex/pull/488

Original API proposal in: https://github.com/dotnet/aspnetcore/issues/42939

## Background and Motivation

In the current implementation, HealthChecks are set to run always. This can cause unneedeed noise, especially during debugging sessions.

We should come up with a simpler mechanism to quickly enable/disable HealthCheck, in order for the developer to focus on the debugging session of the HealthCheck under investigation.

API proposal is to introduce per-HealthCheck `IsEnabled` at the `HealthCheckRegistrationParameters` level, as with the following example:

```csharp

// Usage Example: fetch the registrations from the HealthCheckServiceOptions and disable the target HealthCheck
var registrationParams = healthCheckRegistrationOptions.Value.RegistrationParameters;
registrationParams.First(r => r.Name == "DisabledCheck1").IsEnabled = false;

```

## Usage Examples

<!--
Please provide code examples that highlight how the proposed API additions are meant to be consumed.
This will help suggest whether the API has the right shape to be functional, performant and useable.
You can use code blocks like this:
```csharp
// some lines of code here
```
-->

Based on a JSON Configuration file, user can develop a FileSystemWatcher observing which HealthCheck should be enabled in the current debugging session. Example:

```json
// appsettings.json
"HealthCheckSettings": [
     {
     "HealthCheckName": "GetNamesApiCheck",
     "IsEnabled": false
     },
     {
     "HealthCheckName": "GetActionsApiCheck",
     "IsEnabled": true
     }
]
```

```csharp
// Program.cs
var registrations = healthCheckServiceOptions.Value.Registrations.ToDictionary(r => r.Name, r => r);

foreach (var healthCheckSetting in healthCheckSettings) {
     registrations[healthCheckSetting.HealthCheckName] = healthCheckSetting.IsEnabled;
}
```