### PR TITLE
Fix version to match correct schema - 6.0.400

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.4",
+    "version": "6.0.400",
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
SDK version is not correct, though it seems to work as expected.
This change matches the version to the correct schema.

See comments in https://github.com/microsoft/Omex/pull/495