### PR TITLE
update dimensions to exclude ActivtyId and SpanID to avoid high cardinality

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -4,7 +4,7 @@
     <PackageReference Update="Moq" Version="4.18.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.3.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Csharp" Version="4.3.0" />
-    <PackageReference Update="Microsoft.Net.Test.Sdk" Version="17.3.1" />
+    <PackageReference Update="Microsoft.Net.Test.Sdk" Version="17.3.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />

--- a/Packages.props
+++ b/Packages.props
@@ -4,7 +4,7 @@
     <PackageReference Update="Moq" Version="4.18.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.3.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Csharp" Version="4.3.0" />
-    <PackageReference Update="Microsoft.Net.Test.Sdk" Version="17.3.2" />
+    <PackageReference Update="Microsoft.Net.Test.Sdk" Version="17.3.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />

--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Omex.Extensions.Activities
 
 			foreach (KeyValuePair<string, string?> baggage in activity.Baggage)
 			{
-				
 				tags[index++] = CreatePair(baggage.Key, baggage.Value);
 			}
 
@@ -76,8 +75,6 @@ namespace Microsoft.Omex.Extensions.Activities
 
 		private static readonly Func<ActivityMetricsSender, Activity, KeyValuePair<string, object?>>[] s_customTags = new Func<ActivityMetricsSender, Activity, KeyValuePair<string, object?>>[]
 		{
-			static (sender, activity) => CreatePair("ActivityId", activity.Id),
-			static (sender, activity) => CreatePair("TraceId", activity.TraceId),
 			static (sender, activity) => CreatePair("Name", activity.OperationName),
 			static (sender, activity) => CreatePair("Environment", sender.m_hostEnvironment.EnvironmentName),
 			static (sender, activity) => CreatePair("RegionName", sender.m_context.RegionName),

--- a/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
+++ b/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
@@ -53,28 +53,27 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests.Internal
 				.Stop();
 
 			sender.SendActivityMetric(testActivity);
-			VerifyMeasurement(listener, testActivity, context, environment, s_activityCounterName);
+			VerifyTagsExist(listener, testActivity, false, context, environment, s_activityCounterName);
 
 			Activity testHealthCheckActivity = new(nameof(testHealthCheckActivity));
 			testHealthCheckActivity.Start()
 				.MarkAsHealthCheck()
-				.AddTag("HealthCheckTag", "TagValue")
+				.AddTag(s_healthCheckTag, "TagValue")
 				.AddBaggage("HealthCheckBaggage", "BaggageValue")
 				.Stop();
 
 			sender.SendActivityMetric(testHealthCheckActivity);
-			VerifyMeasurement(listener, testHealthCheckActivity, context, environment, s_heathCheckActivityCounterName);
+			VerifyTagsExist(listener, testHealthCheckActivity, true, context, environment, s_heathCheckActivityCounterName);
 		}
 
-		private void VerifyMeasurement(Listener listener, Activity activity, IExecutionContext context, IHostEnvironment environment, string instrumentationName)
+		private void VerifyTagsExist(Listener listener, Activity activity, bool isHealthCheck, IExecutionContext context, IHostEnvironment environment, string instrumentationName)
 		{
-			// We need to filter by both ActivityId and Enviroment since same activity might be captured and reported by diffirent UT
-			MeasurementResult result = listener.Results.Single(m => activity.Id?.Equals(m.Tags[s_activityIdTagName]) == true && environment.EnvironmentName.Equals(m.Tags[s_environmentTagName]));
+			MeasurementResult result = isHealthCheck ?
+				listener.Results.First(m => m.Tags.ContainsKey(s_healthCheckTag) && environment.EnvironmentName.Equals(m.Tags[s_environmentTagName]))
+				: listener.Results.First(m => !m.Tags.ContainsKey(s_healthCheckTag) && environment.EnvironmentName.Equals(m.Tags[s_environmentTagName]));
 
 			Assert.AreEqual(instrumentationName, result.Instrument.Name);
 			Assert.AreEqual(activity.Duration.TotalMilliseconds, result.Measurement);
-			AssertTag(result, s_activityIdTagName, activity.Id);
-			AssertTag(result, "TraceId", activity.TraceId);
 			AssertTag(result, "Name", activity.OperationName);
 			AssertTag(result, s_environmentTagName, environment.EnvironmentName);
 			AssertTag(result, "RegionName", context.RegionName);
@@ -101,7 +100,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests.Internal
 
 		private static void AssertTag(MeasurementResult result, string key, object? expectedValue) => Assert.AreEqual(expectedValue, result.Tags[key]);
 
-		private static readonly string s_activityIdTagName = "ActivityId";
+		private static readonly string s_healthCheckTag = "HealthCheckTag";
 
 		private static readonly string s_environmentTagName = "Environment";
 


### PR DESCRIPTION
Goal: to remove ActivityId and SpanID dimension to avoid high cardinality.
ActivityID and SpanID are redundant for storing and querying. It adds huge exponential cost.
It is a rule of thumb to not store ID for metrics

Reference: https://lightstep.com/opentelemetry/best-practices/otel-attributes#leverage-cardinality
https://lightstep.com/opentelemetry/best-practices/otel-attributes#leverage-cardinality