### PR TITLE
Remove suppression of NU5104

### DIFF
--- a/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);NU5104</NoWarn> <!-- Allow usage of RC version of Metric API, should be removed after .NET 6 release -->
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Abstractions</Title>


### PR DESCRIPTION
Fixes #251 

This warning should not be suppressed anymore since the package already uses a released version of `System.Diagnostics.DiagnosticSource`. Keep in mind that suppressions that were present before could have allowed referencing other prerelease packages, so if during package update you'll see `NU5104` error package reference should be changed or suppressed in place with an appropriate comment.