### PR TITLE
Revert "Updating Service Fabric to 9.0.1107"

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -38,12 +38,12 @@
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Label="ServiceFabric packages for Omex Extensions">
-    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1107" />
+    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1048" />
     <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.7.1" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1107" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1107" />
-    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1107" />
-    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1107" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.3" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1048" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts microsoft/Omex#501

Preparing to revert Service Fabric update due to Mocks incompatibility.

Mocks is being fixed here:
https://github.com/loekd/ServiceFabric.Mocks/pull/129/files