### PR TITLE
Updating Service Fabric to 9.0.1107

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -38,12 +38,12 @@
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Label="ServiceFabric packages for Omex Extensions">
-    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1048" />
+    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1107" />
     <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.7.1" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1048" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1048" />
-    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1048" />
-    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1048" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.2" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1107" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1107" />
+    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1107" />
+    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1107" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/Packages.props
+++ b/Packages.props
@@ -44,6 +44,6 @@
     <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1107" />
     <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1107" />
     <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1107" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.3" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts microsoft/Omex#506

Also bumps ServiceFabric.Mocks to latest version that supports 1107.