### PR TITLE
Added .NET 6 to targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
     <NetFrameworkVersion>net472</NetFrameworkVersion>
-    <UnitTestTargetFrameworks>$(NetCoreVersions);$(NetFrameworkVersion)</UnitTestTargetFrameworks>
+    <UnitTestTargetFrameworks>$(DefaultNetCoreVersion);$(NetFrameworkVersion)</UnitTestTargetFrameworks>
     <UnitTestTargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions)</UnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="Project Settings" >

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Target Platforms" >
-    <NetCoreVersions>net7.0</NetCoreVersions>
+    <DefaultNetCoreVersion>net7.0</DefaultNetCoreVersion>
+    <NetCoreVersions>$(DefaultNetCoreVersion);net6.0</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>
     <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>

--- a/src/CodeGenerators/SettingsGen.Example/Microsoft.Omex.SettingsGen.Example.csproj
+++ b/src/CodeGenerators/SettingsGen.Example/Microsoft.Omex.SettingsGen.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <!--
     <SettingsFile>$(SolutionDir)\src\CodeGenerators\SettingsGen.Example\Settings.xml</SettingsFile>
     <GenerateSettingsFile>True</GenerateSettingsFile>    -->
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="Settings.xml" Generate="true"/>
+    <AdditionalFiles Include="Settings.xml" Generate="true" />
     <ProjectReference Include="..\SettingsGen\Microsoft.Omex.CodeGenerators.SettingsGen.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
+++ b/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />

--- a/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
+++ b/tests/CodeGenerators/SettingsGen.UnitTests/Microsoft.Omex.CodeGenerators.SettingsGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />

--- a/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
+++ b/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreVersion)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
After bumping dotnet version to 7.0, some teams started having problems with builds.
This PR is to make the transition smoother by readding .NET 6 to targets (will be completely removed only after an announcement in the future)