### PR TITLE
Change monitoring option path

### DIFF
--- a/src/Abstractions/Option/MonitoringOption.cs
+++ b/src/Abstractions/Option/MonitoringOption.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Omex.Extensions.Abstractions.Option
 		/// <summary>
 		/// Path to the setting
 		/// </summary>
-		public static string MonitoringPath = "Monitoring:UseHistogramForActivityMonitoring";
+		public static string MonitoringPath = "Monitoring";
 
 		/// <summary>
 		/// Setting to determine whether using Histogram ar Counter for metrics


### PR DESCRIPTION
Error in mapping option path when using "Parameter" level
```
serviceCollection.AddOptions<MonitoringOption>()
   .BindConfiguration(MonitoringOption.MonitoringPath)
```

my Fix: use "Section" level instead of "Parameter" level