### PR TITLE
ConfigurationValidation - wrapper for IConfiguration nullable checks

### DIFF
--- a/src/Abstractions/ConfigurationValidation.cs
+++ b/src/Abstractions/ConfigurationValidation.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Omex.Extensions.Abstractions
+{
+	/// <summary>
+	/// Class provides common validation methods for Microsoft.Extensions.IConfiguration
+	/// </summary>
+	public static class ConfigurationValidation
+	{
+		/// <summary>
+		/// Omex workaround around IConfigurationSection.Get() returning null variables.
+		/// </summary>
+		/// <typeparam name="T">Type needed from the configuration section</typeparam>
+		/// <param name="configuration">IConfiguration object</param>
+		/// <param name="sectionName">Name of configuration section to get the object from</param>
+		/// <returns>Non-nullable object of type T</returns>
+		/// <exception cref="ArgumentNullException">If the type T is not found in the given section of the configuration</exception>
+		public static T GetNonNullableOrThrow<T>(IConfiguration configuration, string sectionName)
+		{
+			return configuration.GetSection(sectionName).Get<T>()
+				?? throw new InvalidOperationException($"{nameof(T)} missing in the {sectionName} section of the configuration");
+		}
+	}
+}

--- a/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -14,6 +14,7 @@
     <Content Include="BuildTransitive\*" Pack="true" PackagePath="buildTransitive" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/tests/Abstractions.UnitTests/ConfigurationValidationTests.cs
+++ b/tests/Abstractions.UnitTests/ConfigurationValidationTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Omex.Extensions.Abstractions.UnitTests
+{
+	[TestClass]
+	public class ConfigurationValidationTests
+	{
+		[TestMethod]
+		public void GetNonNullableOrThrow_WhenValueNotNull()
+		{
+			// prepare mocks
+			string sectionKeyInt = "SectionKeyInt";
+			string sectionKeyString = "SectionKeyString";
+			string configValueInt = "5";
+			string configValueString = "asdf";
+
+			Mock<IConfigurationSection> mockSectionInt = new Mock<IConfigurationSection>();
+			Mock<IConfigurationSection> mockSectionString = new Mock<IConfigurationSection>();
+			Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
+
+			mockSectionInt.Setup(x => x.Value).Returns(configValueInt);
+			mockSectionString.Setup(x => x.Value).Returns(configValueString);
+			mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == sectionKeyInt))).Returns(mockSectionInt.Object);
+			mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == sectionKeyString))).Returns(mockSectionString.Object);
+
+			// assert
+			int resultInt = ConfigurationValidation.GetNonNullableOrThrow<int>(mockConfig.Object, sectionKeyInt);
+			string resultString = ConfigurationValidation.GetNonNullableOrThrow<string>(mockConfig.Object, sectionKeyString);
+			Assert.AreEqual(resultInt, int.Parse(configValueInt));
+			Assert.AreEqual(resultString, configValueString);
+		}
+
+
+		[TestMethod]
+		public void GetNonNullableOrThrow_WhenValueNull()
+		{
+			// prepare mocks
+			string sectionKey = "SectionKey";
+
+			Mock<IConfigurationSection> mockSection = new Mock<IConfigurationSection>();
+			Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
+
+			mockSection.Setup(x => x.Value).Returns((string?)null);
+			mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == sectionKey))).Returns(mockSection.Object);
+
+			// assert
+			Assert.ThrowsException<InvalidOperationException>(() => ConfigurationValidation.GetNonNullableOrThrow<string>(mockConfig.Object, sectionKey));
+		}
+
+		[TestMethod]
+		public void GetNonNullableOrThrow_WhenWrongType()
+		{
+			// prepare mocks
+			string sectionKey = "SectionKey";
+			string sectionKeyString = "SectionKeyString";
+
+			Mock<IConfigurationSection> mockSection = new Mock<IConfigurationSection>();
+			Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
+
+			mockSection.Setup(x => x.Value).Returns(sectionKeyString);
+			mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == sectionKey))).Returns(mockSection.Object);
+
+			// assert
+			Assert.ThrowsException<InvalidOperationException>(() => ConfigurationValidation.GetNonNullableOrThrow<int>(mockConfig.Object, sectionKey));
+		}
+	}
+}


### PR DESCRIPTION
After changes of nullability of some types in Microsoft.Extensions 7.0.0
- added to simplify and unify nullable checks of IConfiguration objects