### PR TITLE
Added explicit dependency for health checks

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -3,6 +3,7 @@
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Update="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Csharp" Version="4.4.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -21,6 +21,9 @@
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Condition="'$(TargetFramework)' != '$(DefaultNetCoreVersion)'" Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />
     <ProjectReference Include="..\ServiceFabricGuest.Abstractions\Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Microsoft.Extensions.Diagnostics.HealthChecks 7.0.0 targets only net7 and netstandard20. Netstandard20 version (which is consumed by any non-net7 project) fails to reference a required dependency Microsoft.Bcl.AsyncInterfaces, so it has to be added explicitly.