### PR TITLE
Updating to MsTest 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="Package Versions. AutoUpdate">
-    <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Update="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Csharp" Version="4.4.0" />


### PR DESCRIPTION
This was part of the previous package update but reverted while investigating issues with CodeQL.

Also moving CodeQL over to using Ubuntu, windows was being used previously due to older now removed dependencies.