### PR TITLE
Updating Service Fabric to 9.1.1436

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -37,6 +37,6 @@
     <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.8.1" />
     <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.1.1436" />
     <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.1.1436" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="7.0.1" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="6.1.6" />
   </ItemGroup>
 </Project>

--- a/Packages.props
+++ b/Packages.props
@@ -31,12 +31,12 @@
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Label="ServiceFabric packages for Omex Extensions">
-    <PackageReference Update="Microsoft.ServiceFabric" Version="9.0.1121" />
-    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.0.1121" />
-    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.0.1121" />
-    <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.7.1" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.0.1121" />
-    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1121" />
-    <PackageReference Update="ServiceFabric.Mocks" Version="6.1.4" />
+    <PackageReference Update="Microsoft.ServiceFabric" Version="9.1.1436" />
+    <PackageReference Update="Microsoft.ServiceFabric.Actors" Version="6.1.1436" />
+    <PackageReference Update="Microsoft.ServiceFabric.AspNetCore.Abstractions" Version="6.1.1436" />
+    <PackageReference Update="Microsoft.ServiceFabric.Client.Http" Version="4.8.1" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services" Version="6.1.1436" />
+    <PackageReference Update="Microsoft.ServiceFabric.Services.Remoting" Version="6.1.1436" />
+    <PackageReference Update="ServiceFabric.Mocks" Version="7.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Details on Service Fabric Blog:
https://techcommunity.microsoft.com/t5/azure-service-fabric-blog/azure-service-fabric-9-1-first-refresh-is-now-available/ba-p/3698646