### PR TITLE
Move to SDK 7.0.103

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "7.0.103",
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
As per https://github.com/dotnet/sdk/issues/30624 7.0.200 has a breaking change regarding the --output flag.
Moving to 7.0.103 to unblock the move to generating binaries targeting runtime  7.0.3.