### PR TITLE
Add support for attaching transport settings to OmexServiceProxyFactory

### DIFF
--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.ServiceFabric.Services.Remoting.Client;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
 using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client;
 
 namespace Microsoft.Omex.Extensions.Services.Remoting.Client
@@ -11,12 +12,30 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	/// </summary>
 	public static class OmexServiceProxyFactory
 	{
-		/// <summary>
-		/// Instance of the ServiceProxyFactory
-		/// </summary>
-		public static ServiceProxyFactory Instance { get; } = new ServiceProxyFactory(handler =>
+		private static ServiceProxyFactory s_serviceProxyFactory = new ServiceProxyFactory(handler =>
 			new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(
 					remotingCallbackMessageHandler: handler)));
+
+		/// <summary>
+		/// Binds transport settings to the service proxy factory, for use in secure remoting communication.
+		/// </summary>
+		public static void WithTransportSettings(FabricTransportRemotingSettings transportSettings)
+		{
+			s_serviceProxyFactory = new ServiceProxyFactory(handler =>
+				new OmexServiceRemotingClientFactory(
+					new FabricTransportServiceRemotingClientFactory(
+						remotingSettings: transportSettings,
+						remotingCallbackMessageHandler: handler)));
+		}
+
+		/// <summary>
+		/// Instance of the ServiceProxyFactory
+		/// </summary>
+		/// <remarks>
+		/// The default implementation uses insecure connections.
+		/// To use secure connections call <see cref="WithTransportSettings"/> prior to calling .Instance.
+		/// </remarks>
+		public static ServiceProxyFactory Instance => s_serviceProxyFactory;
 	}
 }


### PR DESCRIPTION
Fixes #555 

Adds a fluent interface to OmexServiceProxyFactory so that transport settings can be provided to the underlying service proxy.
This unblocks using secure remoting with Extensions.