### PR TITLE
Update OmexServiceProxyFactory comments

### DIFF
--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -8,8 +8,15 @@ using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client;
 namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 {
 	/// <summary>
-	/// Class to provide ServiceProxyFactory
+	/// Class to provide ServiceProxyFactory wrapper around a Service Fabric remoting client factory.
 	/// </summary>
+	/// <remarks>
+	/// This wrapper exists to bridge the gap between native service proxy constructs and Service Fabric remoting client creation.
+	/// The default Service Fabric remoting client initialization tries to load transport settigns from a 'TransportSettings' section in the service manifest.
+	/// References:
+	/// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/fe1f3b2bf336fab9b97a846414c7b7a57f07833a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs#L226
+	/// https://github.com/microsoft/service-fabric/blob/e212102722634e70fe03bfde36ff3b4b0a23f84c/src/prod/src/managed/Microsoft.ServiceFabric.FabricTransport/FabricTransport/Common/FabricTransportSettings.cs#L300
+	/// </remarks>
 	public static class OmexServiceProxyFactory
 	{
 		private static ServiceProxyFactory s_serviceProxyFactory = new ServiceProxyFactory(handler =>
@@ -18,9 +25,10 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 					remotingCallbackMessageHandler: handler)));
 
 		/// <summary>
-		/// Binds transport settings to the service proxy factory, for use in secure remoting communication.
+		/// Binds custom transport settings to the service proxy factory.
+		/// If non non-default secure remoting configuration is required, call this before calling OmexServiceProxyFactory.Instance.
 		/// </summary>
-		public static void WithTransportSettings(FabricTransportRemotingSettings transportSettings)
+		public static void WithCustomTransportSettings(FabricTransportRemotingSettings transportSettings)
 		{
 			s_serviceProxyFactory = new ServiceProxyFactory(handler =>
 				new OmexServiceRemotingClientFactory(
@@ -34,7 +42,8 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		/// </summary>
 		/// <remarks>
 		/// The default implementation uses insecure connections.
-		/// To use secure connections call <see cref="WithTransportSettings"/> prior to calling .Instance.
+		/// To use secure connections either add a TransportSettings section to the service manifest
+		/// or call <see cref="WithTransportSettings"/> prior to calling .Instance to use custom transport settings configuration.
 		/// </remarks>
 		public static ServiceProxyFactory Instance => s_serviceProxyFactory;
 	}

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	/// </summary>
 	/// <remarks>
 	/// This wrapper exists to bridge the gap between native service proxy constructs and Service Fabric remoting client creation.
-	/// The default Service Fabric remoting client initialization tries to load transport settigns from a 'TransportSettings' section in the service manifest.
+	/// The default Service Fabric remoting client initialization tries to load transport settings from a 'TransportSettings' section in the service manifest.
 	/// References:
 	/// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/master/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs#L108
 	/// https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Microsoft.ServiceFabric.FabricTransport/FabricTransport/Common/FabricTransportSettings.cs#L300

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	/// This wrapper exists to bridge the gap between native service proxy constructs and Service Fabric remoting client creation.
 	/// The default Service Fabric remoting client initialization tries to load transport settigns from a 'TransportSettings' section in the service manifest.
 	/// References:
-	/// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/fe1f3b2bf336fab9b97a846414c7b7a57f07833a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs#L226
-	/// https://github.com/microsoft/service-fabric/blob/e212102722634e70fe03bfde36ff3b4b0a23f84c/src/prod/src/managed/Microsoft.ServiceFabric.FabricTransport/FabricTransport/Common/FabricTransportSettings.cs#L300
+	/// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/master/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs#L108
+	/// https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Microsoft.ServiceFabric.FabricTransport/FabricTransport/Common/FabricTransportSettings.cs#L300
 	/// </remarks>
 	public static class OmexServiceProxyFactory
 	{
@@ -43,7 +43,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		/// <remarks>
 		/// The default implementation uses insecure connections.
 		/// To use secure connections either add a TransportSettings section to the service manifest
-		/// or call <see cref="WithTransportSettings"/> prior to calling .Instance to use custom transport settings configuration.
+		/// or call <see cref="WithCustomTransportSettings"/> prior to calling .Instance to use custom transport settings configuration.
 		/// </remarks>
 		public static ServiceProxyFactory Instance => s_serviceProxyFactory;
 	}

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		/// <remarks>
 		/// The default implementation uses insecure connections.
 		/// To use secure connections either add a TransportSettings section to the service manifest
-		/// or call <see cref="WithCustomTransportSettings"/> prior to calling .Instance to use custom transport settings configuration.
+		/// or call <see cref="WithCustomTransportSettings"/> prior to calling `.Instance` to use custom transport settings configuration.
 		/// </remarks>
 		public static ServiceProxyFactory Instance => s_serviceProxyFactory;
 	}

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 
 		/// <summary>
 		/// Binds custom transport settings to the service proxy factory.
-		/// If non non-default secure remoting configuration is required, call this before calling OmexServiceProxyFactory.Instance.
+		/// If non-default secure remoting configuration is required, call this before calling OmexServiceProxyFactory.Instance.
 		/// </summary>
 		public static void WithCustomTransportSettings(FabricTransportRemotingSettings transportSettings)
 		{


### PR DESCRIPTION
Based on further investigation and discussion around this class, there is no clean way to marry the constraints of the native DI container, ServiceProxy event handling, and binding of activity data to remoting calls, with the lack of flexibility in initialisation of the wrapped Fabric remoting client proxy.

Ideally the Fabric remoting client would allow named clients (or event clients with differing configuration) but it doesn't.

The least-worst refactoring I could envisage was to repurpose OmexServiceProxyFactory as a service proxy factory register/provider and to change the interface to allow addition of named proxy factories which could be independently resolved.
However, after debating the additional complexity this would add, rationalising that there probably aren't any real use cases for changing the transport settings used by a service to identify itself, and investigating the underlying default implementation of the service fabric client proxy factory, we decided that the best thing to do would be to;
- Document this class better so that it's behavior is clearer.
- Not proceed with any significant refactoring, since it would only serve to increase complexity without achieving any significant  gain toward alignment with native .NET idioms.
- Either revert the last PR https://github.com/microsoft/Omex/pull/556 or repurpose the function added to allow the use of transport settings that were not defined in the service manifest.

