### PR TITLE
Added consistency health check marker for Activities

### DIFF
--- a/src/Abstractions/Activities/ActivityExtensions.cs
+++ b/src/Abstractions/Activities/ActivityExtensions.cs
@@ -38,6 +38,15 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 				StringComparison.OrdinalIgnoreCase);
 
 		/// <summary>
+		/// Returns true if the activity belongs to a consistency health check.
+		/// </summary>
+		public static bool IsConsistencyHealthCheck(this Activity activity)	=>
+			string.Equals(
+				activity.GetBaggageItem(ConsistencyHealthCheckMarkerKey),
+				ConsistencyHealthCheckMarkerValue,
+				StringComparison.OrdinalIgnoreCase);
+
+		/// <summary>
 		/// Returns true if activity is marked as Performance test
 		/// </summary>
 		/// <param name="activity">Activity for this request</param>
@@ -64,6 +73,17 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 			activity.IsHealthCheck()
 				? activity
 				: activity.SetBaggage(HealthCheckMarkerKey, HealthCheckMarkerValue);
+
+		/// <summary>
+		/// Mark as consistency health check activity.
+		/// A consistency health check is considered to be an health check that must verify the response
+		/// consistency, but the action it performs cannot be considered as normal traffic.
+		/// </summary>
+		/// <remarks>This property would be transfered to child activity and via web requests</remarks>
+		public static Activity MarkAsConsistencyHealthCheck(this Activity activity) =>
+			activity.IsConsistencyHealthCheck()
+				? activity
+				: activity.SetBaggage(ConsistencyHealthCheckMarkerKey, ConsistencyHealthCheckMarkerValue);
 
 		/// <summary>
 		/// Set result
@@ -141,6 +161,8 @@ namespace Microsoft.Omex.Extensions.Abstractions.Activities
 		private const string UserHashKey = "UserHash";
 		private const string HealthCheckMarkerKey = "HealthCheckMarker";
 		private const string HealthCheckMarkerValue = "true";
+		private const string ConsistencyHealthCheckMarkerKey = "ConsistencyHealthCheckMarker";
+		private const string ConsistencyHealthCheckMarkerValue = "true";
 		private const string PerformanceMarkerKey = "PerformanceTestMarker";
 		private const string PerformanceMarkerValue = "true";
 		private const string ObsoleteCorrelationId = "ObsoleteCorrelationId";

--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Abstractions.Activities;

--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -68,8 +68,13 @@ namespace Microsoft.Omex.Extensions.Activities
 
 			ReadOnlySpan<KeyValuePair<string, object?>> tagsSpan = MemoryExtensions.AsSpan(tags, 0, tagsCount);
 
-			Histogram<double> histogram = activity.IsHealthCheck() ? m_healthCheckActivityHistogram : m_activityHistogram;
-			Counter<double> counter = activity.IsHealthCheck() ? m_healthCheckActivityCounter : m_activityCounter;
+			Histogram<double> histogram = activity.IsHealthCheck() || activity.IsConsistencyHealthCheck()
+				? m_healthCheckActivityHistogram
+				: m_activityHistogram;
+
+			Counter<double> counter = activity.IsHealthCheck() || activity.IsConsistencyHealthCheck()
+				? m_healthCheckActivityCounter
+				: m_activityCounter;
 
 			if (m_monitoringOption.Value.UseHistogramForActivityMonitoring)
 			{

--- a/src/Activities/Internal/EventSource/ActivityEventSender.cs
+++ b/src/Activities/Internal/EventSource/ActivityEventSender.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Omex.Extensions.Activities
 			string name = activity.OperationName;
 			double durationMs = activity.Duration.TotalMilliseconds;
 			string userHash = activity.GetUserHash();
-			bool isHealthCheck = activity.IsHealthCheck();
+			bool isHealthCheck = activity.IsHealthCheck() || activity.IsConsistencyHealthCheck();
 
 			string subtype = NullPlaceholder;
 			string metadata = NullPlaceholder;

--- a/src/Logging/Internal/EventSource/OmexLogEventSender.cs
+++ b/src/Logging/Internal/EventSource/OmexLogEventSender.cs
@@ -55,11 +55,12 @@ namespace Microsoft.Omex.Extensions.Logging
 			Guid obsoleteCorrelationId = Guid.Empty;
 			uint obsoleteTransactionId = 0u;
 			bool isHealthCheck = false;
+
 			if (activity != null)
 			{
 				activityId = activity.Id ?? string.Empty;
 				activityTraceId = activity.TraceId;
-				isHealthCheck = activity.IsHealthCheck();
+				isHealthCheck = activity.IsHealthCheck() || activity.IsConsistencyHealthCheck();
 
 				if (m_options.CurrentValue.AddObsoleteCorrelationToActivity)
 				{

--- a/tests/Abstractions.UnitTests/Activities/ActivityExtensionsTests.cs
+++ b/tests/Abstractions.UnitTests/Activities/ActivityExtensionsTests.cs
@@ -67,6 +67,19 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 		}
 
 		[TestMethod]
+		public void MarkAsConsistencyHealthCheck_AddsMarker()
+		{
+			Activity activity1 = new Activity("HealthCheckTest1");
+			Activity activity2 = new Activity("HealthCheckTest2");
+
+			activity1.MarkAsConsistencyHealthCheck();
+			CheckThatKeyNotDuplicated(activity1.Baggage);
+
+			Assert.IsTrue(activity1.IsConsistencyHealthCheck());
+			Assert.IsFalse(activity2.IsConsistencyHealthCheck());
+		}
+
+		[TestMethod]
 		public void MarkAsPerformanceTest_AddsMarker()
 		{
 			Activity activity1 = new Activity("PerformanceTest1");

--- a/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
+++ b/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Abstractions.Activities;
@@ -23,7 +21,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests.Internal
 		[TestMethod]
 		[DataRow(true)]
 		[DataRow(false)]
-		public void SendActivityMetric_ProduceMetrics(bool useHistogramForActivityMonitoring)
+		public void HealthCheck_SendActivityMetric_ProduceMetrics(bool useHistogramForActivityMonitoring)
 		{
 			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 			Activity.ForceDefaultIdFormat = true;
@@ -70,6 +68,123 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests.Internal
 			Activity testHealthCheckActivity = new(nameof(testHealthCheckActivity));
 			testHealthCheckActivity.Start()
 				.MarkAsHealthCheck()
+				.AddTag(s_healthCheckTag, "TagValue")
+				.AddBaggage("HealthCheckBaggage", "BaggageValue")
+				.Stop();
+
+			sender.SendActivityMetric(testHealthCheckActivity);
+			VerifyTagsExist(listener, testHealthCheckActivity, true, context, environment, s_heathCheckActivityCounterName);
+		}
+
+		[TestMethod]
+		[DataRow(true)]
+		[DataRow(false)]
+		public void ConsistencyHealthCheck_SendActivityMetric_ProduceMetrics(bool useHistogramForActivityMonitoring)
+		{
+			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+			Activity.ForceDefaultIdFormat = true;
+
+			Mock<IExecutionContext> contextMock = new();
+			contextMock.Setup(e => e.RegionName).Returns("MiddleEarthRegion");
+			contextMock.Setup(e => e.Cluster).Returns("TestCluster");
+			contextMock.Setup(e => e.ApplicationName).Returns("TestApplication");
+			contextMock.Setup(e => e.ServiceName).Returns("TestService");
+			contextMock.Setup(e => e.BuildVersion).Returns("21.1.10514.10818");
+			contextMock.Setup(e => e.NodeName).Returns("TestNode");
+			contextMock.Setup(e => e.MachineId).Returns("TestMachineId");
+			contextMock.Setup(e => e.DeploymentSlice).Returns("002");
+			contextMock.Setup(e => e.IsCanary).Returns(true);
+			contextMock.Setup(e => e.IsPrivateDeployment).Returns(false);
+			IExecutionContext context = contextMock.Object;
+
+			Mock<IHostEnvironment> environmentMock = new();
+			environmentMock.Setup(e => e.EnvironmentName).Returns("TestEnv");
+			IHostEnvironment environment = environmentMock.Object;
+
+			Mock<IOptions<MonitoringOption>> mockMonitorOption = new();
+			mockMonitorOption.Setup(options => options.Value).Returns(new MonitoringOption()
+			{
+				UseHistogramForActivityMonitoring = useHistogramForActivityMonitoring
+			});
+			ActivityMetricsSender sender = new(context, environment, mockMonitorOption.Object);
+
+			Listener listener = new();
+
+			Activity testActivity = new(nameof(testActivity));
+			testActivity.Start()
+				.SetSubType("TestSubType")
+				.SetMetadata("TestMetadata")
+				.AddTag("SomeTag", "SomeTagValue")
+				.AddBaggage("SomeBaggage", "SomeBaggageValue")
+				.AddTag("AnotherTag", "AnotherTagValue")
+				.AddBaggage("AnotherBaggage", "AnotherBaggageValue")
+				.Stop();
+
+			sender.SendActivityMetric(testActivity);
+			VerifyTagsExist(listener, testActivity, false, context, environment, s_activityCounterName);
+
+			Activity testHealthCheckActivity = new(nameof(testHealthCheckActivity));
+			testHealthCheckActivity.Start()
+				.MarkAsConsistencyHealthCheck()
+				.AddTag(s_healthCheckTag, "TagValue")
+				.AddBaggage("HealthCheckBaggage", "BaggageValue")
+				.Stop();
+
+			sender.SendActivityMetric(testHealthCheckActivity);
+			VerifyTagsExist(listener, testHealthCheckActivity, true, context, environment, s_heathCheckActivityCounterName);
+		}
+
+		[TestMethod]
+		[DataRow(true)]
+		[DataRow(false)]
+		public void ConsistencyAndNormalHealthCheck_SendActivityMetric_ProduceMetrics(bool useHistogramForActivityMonitoring)
+		{
+			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+			Activity.ForceDefaultIdFormat = true;
+
+			Mock<IExecutionContext> contextMock = new();
+			contextMock.Setup(e => e.RegionName).Returns("MiddleEarthRegion");
+			contextMock.Setup(e => e.Cluster).Returns("TestCluster");
+			contextMock.Setup(e => e.ApplicationName).Returns("TestApplication");
+			contextMock.Setup(e => e.ServiceName).Returns("TestService");
+			contextMock.Setup(e => e.BuildVersion).Returns("21.1.10514.10818");
+			contextMock.Setup(e => e.NodeName).Returns("TestNode");
+			contextMock.Setup(e => e.MachineId).Returns("TestMachineId");
+			contextMock.Setup(e => e.DeploymentSlice).Returns("002");
+			contextMock.Setup(e => e.IsCanary).Returns(true);
+			contextMock.Setup(e => e.IsPrivateDeployment).Returns(false);
+			IExecutionContext context = contextMock.Object;
+
+			Mock<IHostEnvironment> environmentMock = new();
+			environmentMock.Setup(e => e.EnvironmentName).Returns("TestEnv");
+			IHostEnvironment environment = environmentMock.Object;
+
+			Mock<IOptions<MonitoringOption>> mockMonitorOption = new();
+			mockMonitorOption.Setup(options => options.Value).Returns(new MonitoringOption()
+			{
+				UseHistogramForActivityMonitoring = useHistogramForActivityMonitoring
+			});
+			ActivityMetricsSender sender = new(context, environment, mockMonitorOption.Object);
+
+			Listener listener = new();
+
+			Activity testActivity = new(nameof(testActivity));
+			testActivity.Start()
+				.SetSubType("TestSubType")
+				.SetMetadata("TestMetadata")
+				.AddTag("SomeTag", "SomeTagValue")
+				.AddBaggage("SomeBaggage", "SomeBaggageValue")
+				.AddTag("AnotherTag", "AnotherTagValue")
+				.AddBaggage("AnotherBaggage", "AnotherBaggageValue")
+				.Stop();
+
+			sender.SendActivityMetric(testActivity);
+			VerifyTagsExist(listener, testActivity, false, context, environment, s_activityCounterName);
+
+			Activity testHealthCheckActivity = new(nameof(testHealthCheckActivity));
+			testHealthCheckActivity.Start()
+				.MarkAsHealthCheck()
+				.MarkAsConsistencyHealthCheck()
 				.AddTag(s_healthCheckTag, "TagValue")
 				.AddBaggage("HealthCheckBaggage", "BaggageValue")
 				.Stop();


### PR DESCRIPTION
## Summary

This change introduces a new marker for Activities, to track **consistency health checks** for an application.

A consistency health check differentiate itself from a normal health check in that it performs consistency checks on the response returned by the endpoint it targets, so contrary to the normal health check it cannot be short-circuited. Having that it is a health check, though, it should not be considered as part of the normal application traffic, meaning that passive monitoring should not mark these calls as user traffic, or consider these for load feedback.

### Further improvements

The [`AbstractHealthCheck` class](https://github.com/microsoft/Omex/blob/dc2abe5f1da79b88f7ceea0fbb1af7826331e64f/src/Diagnostics.HealthChecks/AbstractHealthCheck.cs#L18) will not be changed in this PR. Intervention on this class like abstracting the marking of the activity created in the overridden method can be discussed in another PR.