### PR TITLE
Updating ServiceFabric.Mocks to 6.2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,6 @@
     <PackageVersion Include="Microsoft.ServiceFabric.Client.Http" Version="4.8.1" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="6.1.1799" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="6.1.1799" />
-    <PackageVersion Include="ServiceFabric.Mocks" Version="6.2.2" />
+    <PackageVersion Include="ServiceFabric.Mocks" Version="6.2.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This version matches the 1799 Service Fabric Update.