### PR TITLE
Use Histogram instead of Counter for metric in OTEL

### DIFF
--- a/src/Abstractions/Option/MonitoringOption.cs
+++ b/src/Abstractions/Option/MonitoringOption.cs
@@ -12,10 +12,5 @@ namespace Microsoft.Omex.Extensions.Abstractions.Option
 		/// Path to the setting
 		/// </summary>
 		public static string MonitoringPath = "Monitoring";
-
-		/// <summary>
-		/// Setting to determine whether using Histogram ar Counter for metrics
-		/// </summary>
-		public bool UseHistogramForActivityMonitoring { get; set; }
 	}
 }


### PR DESCRIPTION
## Context
Follow the documentation: https://eng.ms/docs/products/geneva/metrics/appmetrictutorial/appmetric-otel-histogram
Quote: "In real scenarios, only Histogram is sufficient to cover the Sum as well."

Using Counter is not sufficient to cover both count of activity and duration in OpenTelemetry

## What I did:
1. Remove Counter, use Histogram in ActivityListener.
2. Change data type from Double to Long by folloing the documentation. Since we capture duration at **mili**second, it is no need to have decimal value for milisecond in  activity duration. Also processing double taking more time and error prone because of precision