### PR TITLE
Porting of composable Health Checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,7 +223,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -319,7 +319,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -328,5 +328,8 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
+
+# Disabling VSCode files
+.vscode/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,12 @@
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.16" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.9" />

--- a/Omex.sln
+++ b/Omex.sln
@@ -21,9 +21,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		NuGet.Config = NuGet.Config
-		Packages.props = Packages.props
 		README.md = README.md
 		ship.snk = ship.snk
 	EndProjectSection
@@ -69,6 +69,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Omex.Extensions.Activities.UnitTests", "tests\Activities.UnitTests\Microsoft.Omex.Extensions.Activities.UnitTests.csproj", "{E9123DDF-3D31-48A5-8442-F1DAD516E1A6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions", "src\ServiceFabricGuest.Abstractions\Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj", "{A07BF64C-1B19-4972-83DB-B22BFF26E6B0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore", "src\Diagnostics.HealthChecks.AspNetCore\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj", "{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests", "tests\Diagnostics.HealthChecks.AspNetCore.UnitTests\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj", "{43CE835D-5A71-4689-9297-942EF1233175}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -246,6 +250,22 @@ Global
 		{A07BF64C-1B19-4972-83DB-B22BFF26E6B0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A07BF64C-1B19-4972-83DB-B22BFF26E6B0}.Release|x64.ActiveCfg = Release|Any CPU
 		{A07BF64C-1B19-4972-83DB-B22BFF26E6B0}.Release|x64.Build.0 = Release|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Debug|x64.Build.0 = Debug|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Release|x64.ActiveCfg = Release|Any CPU
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD}.Release|x64.Build.0 = Release|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Debug|x64.Build.0 = Debug|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Release|x64.ActiveCfg = Release|Any CPU
+		{43CE835D-5A71-4689-9297-942EF1233175}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -272,6 +292,8 @@ Global
 		{8520AA74-FDA7-4EC0-B60D-C9A786574443} = {3249ADDB-50EC-4C21-A8F0-65EF444662EE}
 		{E9123DDF-3D31-48A5-8442-F1DAD516E1A6} = {551C93F8-6E89-4954-8905-7F5AC7173285}
 		{A07BF64C-1B19-4972-83DB-B22BFF26E6B0} = {3249ADDB-50EC-4C21-A8F0-65EF444662EE}
+		{7FD8C746-9DB1-4B33-B4A6-95AF5FEF2CCD} = {3249ADDB-50EC-4C21-A8F0-65EF444662EE}
+		{43CE835D-5A71-4689-9297-942EF1233175} = {551C93F8-6E89-4954-8905-7F5AC7173285}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6FB7BCB-BF07-4F19-ACBA-457479D421BB}

--- a/src/Diagnostics.HealthChecks.AspNetCore/ActivityMarkersExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/ActivityMarkersExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore;
+
+/// <summary>
+/// A set of extensions for Activity markers.
+/// </summary>
+public static class ActivityMarkersExtensions
+{
+	/// <summary>
+	/// The key used to identify the Short Circuited Activity.
+	/// </summary>
+	public const string LivenessCheckActivityKey = "LivenessCheckMarker";
+
+	/// <summary>
+	/// The value used to identify the Short Circuited Activity.
+	/// </summary>
+	public const string LivenessCheckActivityValue = "true";
+
+	/// <summary>
+	/// Determines whether the activity has been marked as belonging to a health check whose call should be
+	/// short-circuited.
+	/// </summary>
+	/// <param name="activity">The Activity.</param>
+	/// <returns><c>True</c> if the activity's health check should be short-circuited, <c>False</c> otherwise.</returns>
+	public static bool IsLivenessCheck(this Activity activity) =>
+		string.Equals(activity.GetBaggageItem(LivenessCheckActivityKey), LivenessCheckActivityValue, StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Marks the Activity as belonging to a liveness health check whose call should be short-circuited.
+	/// </summary>
+	/// <param name="activity">The activity.</param>
+	/// <returns>The marked activity.</returns>
+	public static Activity MarkAsLivenessCheck(this Activity activity)
+	{
+		if (!activity.IsLivenessCheck())
+		{
+			return activity.AddBaggage(LivenessCheckActivityKey, LivenessCheckActivityValue);
+		}
+
+		return activity;
+	}
+}

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -29,7 +29,7 @@ public static class HealthCheckComposablesExtensions
 		string? httpClientName = "") =>
 			Composables.HealthCheckComposablesExtensions.CreateHttpHealthCheck(
 				requestBuilder,
-				(context, response, _) => Composables.HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response),
+				async (context, response, _) => await Composables.HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response),
 				activitySource,
 				httpClientFactory,
 				httpClientName: httpClientName,

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore;
+
+/// <summary>
+/// Extension methods for health check decorators configuration.
+/// </summary>
+public static class HealthCheckComposablesExtensions
+{
+	/// <summary>
+	/// Creates a new liveness HTTP endpoint checker health check.
+	/// This health check will only verify the reachability of the endpoint, it will mark the activity as a liveness activity,
+	/// that can trigger the response short-circuiting.
+	/// </summary>
+	/// <param name="requestBuilder">The request builder.</param>
+	/// <param name="activitySource">The activity source.</param>
+	/// <param name="httpClientFactory">The http client factory.</param>
+	/// <param name="httpClientName">The HTTP Client name, if a client with that name was registered in particular.</param>
+	/// <returns>The HTTP endpoint checker health check.</returns>
+	public static IHealthCheck CreateLivenessHttpHealthCheck(
+		Func<HttpRequestMessage> requestBuilder,
+		ActivitySource activitySource,
+		IHttpClientFactory httpClientFactory,
+		string? httpClientName = "") =>
+			Composables.HealthCheckComposablesExtensions.CreateHttpHealthCheck(
+				requestBuilder,
+				(context, response, _) => Composables.HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response),
+				activitySource,
+				httpClientFactory,
+				httpClientName: httpClientName,
+				activityMarker: activity => activity?.MarkAsLivenessCheck());
+}

--- a/src/Diagnostics.HealthChecks.AspNetCore/LivenessCheckActionFilterAttribute.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/LivenessCheckActionFilterAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore;
+
+/// <summary>
+/// This endpoint filter tries to identify whether the current <seealso cref="Activity"/> has been marked
+/// as a Liveness health check. If it is, it returns a 200 response.
+/// </summary>
+public class LivenessCheckActionFilterAttribute : ActionFilterAttribute
+{
+	/// <inheritdoc />
+	public override void OnActionExecuting(ActionExecutingContext context)
+	{
+		if (Activity.Current?.IsLivenessCheck() == true)
+		{
+			context.Result = new OkObjectResult("Running test healthcheck transaction");
+		}
+	}
+}

--- a/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
+++ b/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Label="NuGet Properties">
+    <Title>Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore</Title>
+    <Summary>Microsoft Omex Extensions Diagnostics HealthChecks.AspNetCore</Summary>
+    <Description>This library adds support to Omex Health Checks to ASP.NET Core controllers.</Description>
+    <ReleaseNotes>Initial release.</ReleaseNotes>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Diagnostics.HealthChecks</PackageProjectUrl>
+    <PackageTags>Microsoft;Omex;Extensions;HealthChecks;AspNetCore</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Diagnostics.HealthChecks/AbstractHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/AbstractHealthCheck.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 	/// <summary>
 	/// Base health check that extracts logic of exception handling and wraps it into activity
 	/// </summary>
-	[Obsolete("The usage of this class is deprecated, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
+	[Obsolete("The usage of this class is deprecated and will be removed in a later release, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	public abstract class AbstractHealthCheck<TParameters> : IHealthCheck
 		where TParameters : HealthCheckParameters
 	{

--- a/src/Diagnostics.HealthChecks/AbstractHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/AbstractHealthCheck.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 	/// <summary>
 	/// Base health check that extracts logic of exception handling and wraps it into activity
 	/// </summary>
+	[Obsolete("The usage of this class is deprecated, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	public abstract class AbstractHealthCheck<TParameters> : IHealthCheck
 		where TParameters : HealthCheckParameters
 	{
@@ -43,7 +44,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <inheritdoc />
 		public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken token = default)
 		{
-			string activityName = string.IsNullOrWhiteSpace(context.Registration.Name) ? "HealthCheckActivity" : context.Registration.Name; 
+			string activityName = string.IsNullOrWhiteSpace(context.Registration.Name) ? "HealthCheckActivity" : context.Registration.Name;
 			using Activity? activity = m_activitySource.StartActivity(activityName)
 				?.MarkAsSystemError()
 				.MarkAsHealthCheck();

--- a/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+
+/// <summary>
+/// Extension methods for health check decorators configuration.
+/// </summary>
+public static class HealthCheckComposablesExtensions
+{
+	/// <summary>
+	/// Makes the Health check executable only at startup time, adding also observability to it.
+	/// If the consumer health check of this extension method does not want automatic observability,
+	/// the developer is encouraged to wrap it directly around the <see cref="StartupHealthCheck"/> class.
+	/// </summary>
+	/// <param name="healthCheck">The health check.</param>
+	/// <param name="cache">The memory cache. It will be used to memorise the latest health check result.</param>
+	/// <param name="activitySource">The activity source.</param>
+	/// <param name="logger">The logger.</param>
+	/// <param name="parameters">The health check parameters, set at DI registration time.</param>
+	/// <returns>The health check executable only at deploy time.</returns>
+	public static IHealthCheck AsObservableStartupHealthCheck(
+		this IHealthCheck healthCheck,
+		IMemoryCache cache,
+		ActivitySource activitySource,
+		ILogger logger,
+		HealthCheckParameters? parameters = null)
+	{
+		IHealthCheck startupHealthCheck = new StartupHealthCheck(healthCheck, cache);
+		return new ObservableHealthCheck(parameters ?? new(), startupHealthCheck, activitySource, logger);
+	}
+
+	/// <summary>
+	/// Applies the default error handling and activity around the current health check.
+	/// </summary>
+	/// The instance of the Activity marker. By selecting the implementor, the health check will determine how
+	/// the related endpoint will process the health check request.
+	/// <param name="healthCheck">The health check.</param>
+	/// <param name="activitySource">The activity source.</param>
+	/// <param name="logger">The logger.</param>
+	/// <param name="parameters">The health check parameters, set at DI registration time.</param>
+	/// <returns>The health check with the default configuration and error handling.</returns>
+	public static IHealthCheck AsObservableHealthCheck(
+		this IHealthCheck healthCheck,
+		ActivitySource activitySource,
+		ILogger logger,
+		HealthCheckParameters? parameters = null) =>
+		new ObservableHealthCheck(parameters ?? new(), healthCheck, activitySource, logger);
+
+	/// <summary>
+	/// Creates a new HTTP endpoint checker health check.
+	/// </summary>
+	/// <param name="httpClientFactory">The http client factory.</param>
+	/// <param name="requestBuilder">The request builder.</param>
+	/// <param name="healthCheckResponseChecker">The response checker instance.</param>
+	/// <param name="activitySource">The activity source.</param>
+	/// <param name="httpClientName">The HTTP Client name, if a client with that name was registered in particular.</param>
+	/// <param name="activityMarker">Marks the activity with the required baggage items.</param>
+	/// <returns>The HTTP endpoint checker health check.</returns>
+	public static IHealthCheck CreateHttpHealthCheck(
+		Func<HttpRequestMessage> requestBuilder,
+		Func<HealthCheckContext, HttpResponseMessage, CancellationToken, Task<HealthCheckResult>> healthCheckResponseChecker,
+		ActivitySource activitySource,
+		IHttpClientFactory httpClientFactory,
+		string? httpClientName = "",
+		Action<Activity?>? activityMarker = null) =>
+			new HttpEndpointHealthCheck(
+				httpClientFactory,
+				requestBuilder,
+				healthCheckResponseChecker,
+				activitySource,
+				httpClientName: httpClientName,
+				activityMarker: activityMarker);
+
+	/// <summary>
+	/// Checks whether the response from the endpoint is successful or not by checking its HTTP Status Code.
+	/// </summary>
+	/// <param name="context">The Health Check Context.</param>
+	/// <param name="response">The endpoint response.</param>
+	/// <param name="allowedStatusCodes">The allowed status codes for the response..</param>
+	/// <returns>The health check result.</returns>
+	public static Task<HealthCheckResult> CheckResponseStatusCodeAsync(
+		HealthCheckContext context,
+		HttpResponseMessage response,
+		HttpStatusCode[]? allowedStatusCodes = null)
+	{
+		if (allowedStatusCodes == null || allowedStatusCodes.Length == 0)
+		{
+			allowedStatusCodes = new[] { HttpStatusCode.OK };
+		}
+
+		if (allowedStatusCodes.Contains(response.StatusCode))
+		{
+			return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy, "The endpoint returned an allowed status code."));
+		}
+
+		return Task.FromResult(
+			new HealthCheckResult(
+				context.Registration.FailureStatus,
+				$"The endpoint returned an unallowed status code. Status code returned: '{response.StatusCode}'. " +
+				$"Allowed status codes: '{string.Join(", ", allowedStatusCodes.Select(h => h.ToString()))}'"));
+	}
+}

--- a/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
@@ -89,7 +89,7 @@ public static class HealthCheckComposablesExtensions
 	/// <param name="response">The endpoint response.</param>
 	/// <param name="allowedStatusCodes">The allowed status codes for the response..</param>
 	/// <returns>The health check result.</returns>
-	public static Task<HealthCheckResult> CheckResponseStatusCodeAsync(
+	public static async Task<HealthCheckResult> CheckResponseStatusCodeAsync(
 		HealthCheckContext context,
 		HttpResponseMessage response,
 		HttpStatusCode[]? allowedStatusCodes = null)
@@ -101,10 +101,10 @@ public static class HealthCheckComposablesExtensions
 
 		if (allowedStatusCodes.Contains(response.StatusCode))
 		{
-			return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy, "The endpoint returned an allowed status code."));
+			return await Task.FromResult(new HealthCheckResult(HealthStatus.Healthy, "The endpoint returned an allowed status code."));
 		}
 
-		return Task.FromResult(
+		return await Task.FromResult(
 			new HealthCheckResult(
 				context.Registration.FailureStatus,
 				$"The endpoint returned an unallowed status code. Status code returned: '{response.StatusCode}'. " +

--- a/src/Diagnostics.HealthChecks/Composables/HealthCheckConstants.cs
+++ b/src/Diagnostics.HealthChecks/Composables/HealthCheckConstants.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+
+/// <summary>
+/// A series of constants used by health checks.
+/// </summary>
+public static class HealthCheckConstants
+{
+	/// <summary>
+	/// The local service default host.
+	/// </summary>
+	public const string LocalServiceDefaultHost = "localhost";
+}

--- a/src/Diagnostics.HealthChecks/Composables/HttpEndpointHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Composables/HttpEndpointHealthCheck.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+
+/// <summary>
+/// Performs an HTTP endpoint call and then checks the result of the call.
+/// </summary>
+public sealed class HttpEndpointHealthCheck : IHealthCheck
+{
+	private const string ActivityName = nameof(HttpEndpointHealthCheck);
+
+	private readonly IHttpClientFactory m_httpClientFactory;
+	private readonly Func<HttpRequestMessage> m_requestBuilder;
+	private readonly Func<HealthCheckContext, HttpResponseMessage, CancellationToken, Task<HealthCheckResult>> m_healthCheckResponseChecker;
+	private readonly Action<Activity?>? m_activityMarker;
+	private readonly ActivitySource m_activitySource;
+	private readonly string? m_httpClientName;
+
+	/// <summary>
+	/// Constructor.
+	/// </summary>
+	/// <param name="httpClientFactory">The HTTP Client factory.</param>
+	/// <param name="requestBuilder">Function that returns the request.</param>
+	/// <param name="healthCheckResponseChecker">Function that checks the HTTP response from the health check targeted endpoing.</param>
+	/// <param name="activitySource">The activity source for observability.</param>
+	/// <param name="httpClientName">The name of the HTTP Client, if a particular client with that registration name has been defined.</param>
+	/// <param name="activityMarker">Delegate that marks the activity with the desired bagging items.</param>
+	public HttpEndpointHealthCheck(
+		IHttpClientFactory httpClientFactory,
+		Func<HttpRequestMessage> requestBuilder,
+		Func<HealthCheckContext, HttpResponseMessage, CancellationToken, Task<HealthCheckResult>> healthCheckResponseChecker,
+		ActivitySource activitySource,
+		string? httpClientName = "",
+		Action<Activity?>? activityMarker = null)
+	{
+		m_httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+		m_requestBuilder = requestBuilder ?? throw new ArgumentNullException(nameof(requestBuilder));
+		m_healthCheckResponseChecker = healthCheckResponseChecker ?? throw new ArgumentNullException(nameof(healthCheckResponseChecker));
+		m_activitySource = activitySource ?? throw new ArgumentNullException(nameof(activitySource));
+		m_httpClientName = httpClientName;
+		m_activityMarker = activityMarker;
+	}
+
+	/// <inheritdoc />
+	public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	{
+		using Activity? activity = m_activitySource.StartActivity($"{context.Registration.Name}_{ActivityName}");
+		m_activityMarker?.Invoke(activity);
+
+		HttpClient httpClient = m_httpClientName == null || string.IsNullOrWhiteSpace(m_httpClientName)
+			? m_httpClientFactory.CreateClient()
+			: m_httpClientFactory.CreateClient(m_httpClientName);
+
+		HttpRequestMessage request = m_requestBuilder();
+
+		try
+		{
+			HttpResponseMessage? response = await httpClient.SendAsync(request, cancellationToken);
+
+			HealthStatus healthStatus = HealthStatus.Unhealthy;
+			string description = string.Empty;
+
+			if (response != null)
+			{
+				return await m_healthCheckResponseChecker(context, response, cancellationToken);
+			}
+
+			HealthCheckResult result = new(healthStatus, description);
+
+			return result;
+		}
+		catch (HttpRequestException ex)
+		{
+			return new HealthCheckResult(
+				context.Registration.FailureStatus,
+#if NET5_0_OR_GREATER
+				description: $"HTTP Health Check failed with Status Code '{ex.StatusCode}'",
+#else
+				description: $"HTTP Health Check failed",
+#endif
+				exception: ex);
+		}
+		catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+		{
+			return new HealthCheckResult(
+				context.Registration.FailureStatus,
+				description: $"HTTP Health Check failed for timeout.",
+				exception: ex);
+		}
+	}
+}

--- a/src/Diagnostics.HealthChecks/Composables/ObservableHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Composables/ObservableHealthCheck.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Omex.Extensions.Abstractions;
+using Microsoft.Omex.Extensions.Abstractions.Activities;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+
+/// <summary>
+/// The observable health check. This Health Check should wrap every other IHealthCheck instance.
+/// The responsibility of this health check decorator is to configure telemetry for the health check activity,
+/// and handle the exception thrown by wrapped components, to return a health check result consistent
+/// with the Health Check parameters.
+/// </summary>
+public sealed class ObservableHealthCheck : IHealthCheck
+{
+	private readonly HealthCheckParameters m_parameters;
+	private readonly IHealthCheck m_wrappedHealthCheck;
+	private readonly ActivitySource m_activitySource;
+	private readonly ILogger m_logger;
+
+	/// <summary>
+	/// Constructor.
+	/// </summary>
+	/// <param name="parameters">
+	/// The health check parameters passed at DI configuration time.
+	/// They can be used to specify escalation configuration (e.g. the IcM ticket severity, owning team),
+	/// </param>
+	/// <param name="healthCheck">The health check instance to wrap.</param>
+	/// <param name="activitySource">The activity source.</param>
+	/// <param name="logger">The logger.</param>
+	public ObservableHealthCheck(
+		HealthCheckParameters parameters,
+		IHealthCheck healthCheck,
+		ActivitySource activitySource,
+		ILogger logger)
+	{
+		m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+		m_wrappedHealthCheck = healthCheck ?? throw new ArgumentNullException(nameof(healthCheck));
+		m_activitySource = activitySource ?? throw new ArgumentNullException(nameof(activitySource));
+		m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+	}
+
+	/// <inheritdoc />
+	public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	{
+		using Activity? activity = m_activitySource.StartActivity(context.Registration.Name)
+			?.MarkAsHealthCheck()
+			?.MarkAsSystemError();
+
+		try
+		{
+			HealthCheckResult result = await m_wrappedHealthCheck.CheckHealthAsync(context, cancellationToken);
+			activity?.MarkAsSuccess();
+
+			// The health status for the health check result: if the status is healthy, it will be returned as it is,
+			// if not then then registration failure status will be sent in its place.
+			HealthStatus healthCheckStatus = result.Status == HealthStatus.Healthy
+				? result.Status
+				: context.Registration.FailureStatus;
+
+			return new HealthCheckResult(
+				healthCheckStatus,
+				result.Description,
+				data: m_parameters.ReportData,
+				exception: result.Exception);
+		}
+		catch (Exception ex)
+		{
+			m_logger.LogError(Tag.Create(), ex, "'{0}' check failed with exception", context.Registration.Name);
+			return new HealthCheckResult(context.Registration.FailureStatus, "HealthCheck failed", ex, data: m_parameters.ReportData);
+		}
+	}
+}

--- a/src/Diagnostics.HealthChecks/Composables/StartupHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Composables/StartupHealthCheck.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+
+/// <summary>
+/// Wraps the execution of a health check. The execution will be retried until the health check will succeed
+/// of the service will be killed. If the call succeeds, the response will be saved in a memory cache, and
+/// the health check execution will cease.
+/// </summary>
+public sealed class StartupHealthCheck : IHealthCheck
+{
+	private readonly IMemoryCache m_memoryCache;
+	private readonly IHealthCheck m_wrappedHealthCheck;
+
+	/// <summary>
+	/// Constructor.
+	/// </summary>
+	/// <param name="healthCheck">The wrapped health check, whose check method will be called.</param>
+	/// <param name="memoryCache">
+	/// The memory cache instance to register the health check result.
+	/// </param>
+	public StartupHealthCheck(
+		IHealthCheck healthCheck,
+		IMemoryCache memoryCache)
+	{
+		m_wrappedHealthCheck = healthCheck ?? throw new ArgumentNullException(nameof(healthCheck));
+		m_memoryCache = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
+	}
+
+	/// <inheritdoc />
+	public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	{
+		string healthCheckRegistrationName = context.Registration.Name;
+
+		if (TryGetHealthyStatusCached(healthCheckRegistrationName, out HealthCheckResult cachedResult))
+		{
+			return cachedResult;
+		}
+
+		// The execution will not be wrapped in an exception, because if the health check throws an exception,
+		// the health check has not succeeded, and it will not be saved.
+		HealthCheckResult result = await m_wrappedHealthCheck.CheckHealthAsync(context, cancellationToken);
+
+		CacheHealthyStatus(healthCheckRegistrationName, result);
+
+		return result;
+	}
+
+	/// <summary>
+	/// Uses the in-memory cache to check whether the health check has been already performed or not.
+	/// </summary>
+	/// <param name="healthCheckRegistrationName">The health check registration name.</param>
+	/// <param name="result">The cached result.</param>
+	/// <returns><c>True</c> if the health check has been performed already, <c>False</c> otherwise.</returns>
+	private bool TryGetHealthyStatusCached(string healthCheckRegistrationName, out HealthCheckResult result) =>
+		m_memoryCache.TryGetValue(healthCheckRegistrationName, out result) &&
+		result.Status == HealthStatus.Healthy;
+
+	/// <summary>
+	/// Uses the in-memory cache to set a value indicating that the check has been already performed.
+	/// </summary>
+	/// <param name="healthCheckRegistrationName">The health check registration name.</param>
+	/// <param name="result">The result of the health check.</param>
+	/// <returns><c>True</c> if the health check has been performed already, <c>False</c> otherwise.</returns>
+	private void CacheHealthyStatus(string healthCheckRegistrationName, HealthCheckResult result)
+	{
+		if (result.Status == HealthStatus.Healthy)
+		{
+			m_memoryCache.Set(healthCheckRegistrationName, result);
+		}
+	}
+}

--- a/src/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <param name="failureStatus">status that should be reported when the health check reports a failure, if the provided value is null, Unhealthy will be reported Unhealthy</param>
 		/// <param name="additionalCheck">action that would be called after getting response, function should return new result object that would be reported</param>
 		/// <param name="reportData">additional properties that will be attached to health check result, for example escalation info</param>
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddHttpEndpointCheck(
 			this IHealthChecksBuilder builder,
 			string name,
@@ -98,7 +98,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <param name="failureStatus">status that should be reported when the health check reports a failure, if the provided value is null, Unhealthy will be reported Unhealthy</param>
 		/// <param name="additionalCheck">action that would be called after getting response, function should return new result object that would be reported</param>
 		/// <param name="reportData">additional properties that will be attached to health check result, for example escalation info</param>
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddHttpEndpointCheck(
 			this IHealthChecksBuilder builder,
 			string name,

--- a/src/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <param name="failureStatus">status that should be reported when the health check reports a failure, if the provided value is null, Unhealthy will be reported Unhealthy</param>
 		/// <param name="additionalCheck">action that would be called after getting response, function should return new result object that would be reported</param>
 		/// <param name="reportData">additional properties that will be attached to health check result, for example escalation info</param>
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddHttpEndpointCheck(
 			this IHealthChecksBuilder builder,
 			string name,
@@ -97,6 +98,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <param name="failureStatus">status that should be reported when the health check reports a failure, if the provided value is null, Unhealthy will be reported Unhealthy</param>
 		/// <param name="additionalCheck">action that would be called after getting response, function should return new result object that would be reported</param>
 		/// <param name="reportData">additional properties that will be attached to health check result, for example escalation info</param>
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddHttpEndpointCheck(
 			this IHealthChecksBuilder builder,
 			string name,

--- a/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
@@ -12,6 +13,7 @@ using Microsoft.Omex.Extensions.Abstractions;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
+	[Obsolete("The usage of this class is deprecated, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	internal class HttpEndpointHealthCheck : AbstractHealthCheck<HttpHealthCheckParameters>
 	{
 		public static string HttpClientLogicalName { get; } = "HttpEndpointHealthCheckHttpClient";

--- a/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -13,7 +13,7 @@ using Microsoft.Omex.Extensions.Abstractions;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 {
-	[Obsolete("The usage of this class is deprecated, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
+	[Obsolete("The usage of this class is deprecated and will be removed in a later release, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	internal class HttpEndpointHealthCheck : AbstractHealthCheck<HttpHealthCheckParameters>
 	{
 		public static string HttpClientLogicalName { get; } = "HttpEndpointHealthCheckHttpClient";

--- a/src/Diagnostics.HealthChecks/Internal/ServiceContextHealthStatusSender.cs
+++ b/src/Diagnostics.HealthChecks/Internal/ServiceContextHealthStatusSender.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 			m_logger = logger;
 		}
 
-		public Task<bool> IntializeAsync(CancellationToken token)
+		public async Task<bool> IntializeAsync(CancellationToken token)
 		{
 			IServicePartition? partition = m_partitionAccessor.Value;
 			if (partition == null)
@@ -46,7 +46,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 				};
 			}
 
-			return Task.FromResult(m_reportHealth != null);
+			return await Task.FromResult(m_reportHealth != null);
 		}
 
 		public Task SendStatusAsync(string checkName, HealthStatus status, string description, CancellationToken token)

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -15,8 +15,10 @@
     <PackageReference Include="Microsoft.ServiceFabric" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
   <ItemGroup Condition="!$(IsNetCore)">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Add dependencies for a publisher
 		/// </summary>
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IServiceCollection AddPublisherDependencies(this IServiceCollection serviceCollection)
 		{
 			// HttpClient registration only needed for HttpEndpointHealthCheck.
@@ -41,12 +43,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Register publisher for processing health check results directly to replicas
 		/// </summary>
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddServiceFabricHealthChecks(this IServiceCollection serviceCollection) =>
 			serviceCollection.AddOmexHealthCheckDependencies<ServiceContextHealthStatusSender>();
 
 		/// <summary>
 		/// Register publisher for processing health check results directly to nodes using REST api
 		/// </summary>
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddRestHealthChecksPublisher(this IServiceCollection serviceCollection) =>
 			serviceCollection
 				.AddServiceFabricClient()
@@ -55,6 +59,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Register publisher for processing health check results
 		/// </summary>
+
+		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IHealthChecksBuilder AddOmexHealthCheckDependencies<TStatusSender>(this IServiceCollection serviceCollection)
 				where TStatusSender : class, IHealthStatusSender
 		{

--- a/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Register publisher for processing health check results directly to replicas
 		/// </summary>
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddServiceFabricHealthChecks(this IServiceCollection serviceCollection) =>
 			serviceCollection.AddOmexHealthCheckDependencies<ServiceContextHealthStatusSender>();
 
 		/// <summary>
 		/// Register publisher for processing health check results directly to nodes using REST api
 		/// </summary>
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddRestHealthChecksPublisher(this IServiceCollection serviceCollection) =>
 			serviceCollection
 				.AddServiceFabricClient()
@@ -60,7 +60,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// Register publisher for processing health check results
 		/// </summary>
 
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IHealthChecksBuilder AddOmexHealthCheckDependencies<TStatusSender>(this IServiceCollection serviceCollection)
 				where TStatusSender : class, IHealthStatusSender
 		{

--- a/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Add dependencies for a publisher
 		/// </summary>
-		[Obsolete("This method is deprecated, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
+		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IServiceCollection AddPublisherDependencies(this IServiceCollection serviceCollection)
 		{
 			// HttpClient registration only needed for HttpEndpointHealthCheck.

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthCheckActivityMarkersTests.cs
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthCheckActivityMarkersTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables;
+
+[TestClass]
+public class HealthCheckActivityMarkersTests
+{
+	[TestMethod]
+	public void FilterLivenessCheckActionFilter_ReturnsOkForShortCircuit()
+	{
+		ActivitySource activitySource = new(nameof(HealthCheckActivityMarkersTests));
+		DefaultHttpContext httpContext = new();
+		ActionExecutingContext context = new(
+			new ActionContext(
+				httpContext: httpContext,
+				routeData: new(),
+				actionDescriptor: new(),
+				modelState: new()
+			),
+			new List<IFilterMetadata>(),
+			new Dictionary<string, object?>(),
+			new Mock<Controller>().Object);
+
+		LivenessCheckActionFilterAttribute filterAttribute = new();
+		Activity.Current = new Activity(nameof(FilterLivenessCheckActionFilter_ReturnsOkForShortCircuit))
+			.MarkAsLivenessCheck()
+			.Start();
+
+		filterAttribute.OnActionExecuting(context);
+
+		Assert.IsTrue(context.Result is OkObjectResult);
+
+		Activity.Current = null;
+	}
+
+	[TestMethod]
+	public void FilterLivenessCheckActionFilter_ReturnsContextResultForNonShortCircuit()
+	{
+		ActivitySource activitySource = new(nameof(HealthCheckActivityMarkersTests));
+		DefaultHttpContext httpContext = new();
+		ActionExecutingContext context = new(
+			new ActionContext(
+				httpContext: httpContext,
+				routeData: new(),
+				actionDescriptor: new(),
+				modelState: new()
+			),
+			new List<IFilterMetadata>(),
+			new Dictionary<string, object?>(),
+			new Mock<Controller>().Object);
+
+		LivenessCheckActionFilterAttribute filterAttribute = new();
+		Activity.Current = new Activity(nameof(FilterLivenessCheckActionFilter_ReturnsContextResultForNonShortCircuit))
+			.Start();
+
+		filterAttribute.OnActionExecuting(context);
+
+		Assert.IsTrue(context.Result is null);
+
+		Activity.Current = null;
+	}
+
+	private static Mock<IMemoryCache> GetMemoryCacheMock(bool value, string repeatOnceMemoryCacheKey)
+	{
+		Mock<ICacheEntry> entry = new();
+		entry.Setup(e => e.Value)
+			.Returns(value);
+
+		Mock<IMemoryCache> memoryCacheMock = new();
+		memoryCacheMock.Setup(c => c.CreateEntry(repeatOnceMemoryCacheKey))
+			.Returns(entry.Object);
+
+		object? castedValue = value;
+
+		memoryCacheMock.Setup(c => c.TryGetValue(repeatOnceMemoryCacheKey, out castedValue))
+			.Returns(true);
+
+		return memoryCacheMock;
+	}
+}

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Diagnostics.HealthChecks.AspNetCore\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />
+    <ProjectReference Include="..\Abstractions.UnitTests\Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj" />
+    <ProjectReference Include="..\Diagnostics.HealthChecks.UnitTests\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+  </ItemGroup>
+</Project>

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/StartupHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/StartupHealthCheckTests.cs
@@ -74,14 +74,14 @@ internal class FailingThreeTimeHealthCheck : IHealthCheck
 {
 	private int m_count = 0;
 
-	public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
 	{
 		if (m_count < 2)
 		{
 			Interlocked.Increment(ref m_count);
-			return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy));
+			return await Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy));
 		}
 
-		return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+		return await Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
 	}
 }

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/StartupHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/StartupHealthCheckTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables;
+
+[TestClass]
+public class StartupHealthCheckTests
+{
+	private static readonly ActivitySource s_activitySource = new(nameof(StartupHealthCheckTests));
+
+	private static readonly ILogger s_logger = NullLogger.Instance;
+
+	[TestMethod]
+	[DataRow(HealthStatus.Healthy)]
+	[DataRow(HealthStatus.Unhealthy)]
+	[DataRow(HealthStatus.Degraded)]
+	public async Task StartupHealthCheck_ShouldReturnGivenState_WhenHealthCheckHasGivenStatus(HealthStatus healthStatus)
+	{
+		IMemoryCache memoryCacheMock = new MemoryCache(new MemoryCacheOptions());
+		Mock<IHealthCheck> healthCheckMock = new();
+		healthCheckMock.Setup(hc => hc.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new HealthCheckResult(healthStatus));
+
+		StartupHealthCheck monitorHealthCheck = new(healthCheckMock.Object, memoryCacheMock);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult result = await monitorHealthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(monitorHealthCheck),
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(healthStatus, result.Status);
+	}
+
+	[TestMethod]
+	public async Task CheckHealthAsync_WithThreeRun_ShouldReturnHealthy()
+	{
+		IHealthCheck wrappedHealthCheck = new FailingThreeTimeHealthCheck();
+
+		IMemoryCache memoryCacheMock = new MemoryCache(new MemoryCacheOptions());
+		CancellationTokenSource source = new();
+		IHealthCheck healthCheck = new StartupHealthCheck(wrappedHealthCheck, memoryCacheMock);
+
+		for (int i = 0; i < 3; i++)
+		{
+			_ = await healthCheck.CheckHealthAsync(HealthCheckTestHelpers.GetHealthCheckContext(healthCheck), source.Token);
+		}
+
+		HealthCheckResult response = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		HealthCheckResult responseAfterFirstOk = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.AreEqual(HealthStatus.Healthy, response.Status);
+		Assert.AreEqual(HealthStatus.Healthy, responseAfterFirstOk.Status);
+	}
+}
+
+internal class FailingThreeTimeHealthCheck : IHealthCheck
+{
+	private int m_count = 0;
+
+	public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	{
+		if (m_count < 2)
+		{
+			Interlocked.Increment(ref m_count);
+			return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy));
+		}
+
+		return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+	}
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/AbstractHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/AbstractHealthCheckTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 	public class AbstractHealthCheckTests
 	{
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task AbstractHealthCheck_PropagatesParametersAndResult()
 		{
 			HealthCheckResult expectedResult = HealthCheckResult.Healthy("test");
@@ -42,6 +43,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task AbstractHealthCheck_WhenExceptionThrown_ReturnsUnhealtyState()
 		{
 			using TestActivityListener listener = new();
@@ -64,6 +66,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task AbstractHealthCheck_MarksActivityWithHealthCheckFlag()
 		{
 			using TestActivityListener listener = new();
@@ -81,6 +84,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			activity.AssertResult(ActivityResult.Success);
 		}
 
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		private class TestHealthCheck : AbstractHealthCheck<HealthCheckParameters>
 		{
 			private readonly Func<HealthCheckContext, CancellationToken, HealthCheckResult> m_internalFunction;

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/HealthCheckTestHelpers.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/HealthCheckTestHelpers.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables;
+
+/// <summary>
+/// A collection of helpers to test the health checks.
+/// </summary>
+public static class HealthCheckTestHelpers
+{
+	internal const HealthStatus RegisteredUnhealthyHealthStatus = HealthStatus.Unhealthy;
+	internal const string HealthCheckMockRegistrationName = "some-name";
+
+	/// <summary>
+	/// Returns an instance of the health check context.
+	/// </summary>
+	/// <param name="instance">The health check instance.</param>
+	/// <param name="registeredFailedHealthStatus">
+	/// The health status that the registration should hint in case the health check fails.
+	/// </param>
+	/// <returns>The health check context instance.</returns>
+	public static HealthCheckContext GetHealthCheckContext(
+		IHealthCheck instance,
+		HealthStatus? registeredFailedHealthStatus = null) =>
+		new()
+		{
+			Registration = new(
+				HealthCheckMockRegistrationName,
+				instance,
+				registeredFailedHealthStatus ?? RegisteredUnhealthyHealthStatus,
+				Array.Empty<string>())
+		};
+
+	/// <summary>
+	/// Gets a new Logger instance that registers the logged messages.
+	/// </summary>
+	/// <returns>The logger messages.</returns>
+	internal static InMemoryLogger GetLoggerInstance() => new();
+
+	/// <summary>
+	/// Gets a new Logger instance with a generic parameter that registers the logged messages.
+	/// </summary>
+	/// <returns>The logger messages.</returns>
+	internal static InMemoryLogger<TInstance> GetLoggerInstance<TInstance>() => new();
+
+	public class InMemoryLogger<TInstance> : InMemoryLogger, ILogger<TInstance>
+	{
+		protected override ILogger InternalLogger => NullLogger<TInstance>.Instance;
+	}
+
+	public class InMemoryLogger : ILogger
+	{
+		protected virtual ILogger InternalLogger => NullLogger.Instance;
+
+		private static readonly IList<string> s_list = new List<string>();
+
+		public IDisposable? BeginScope<TState>(TState state)
+			where TState : notnull =>
+				InternalLogger.BeginScope(state);
+
+		public bool IsEnabled(LogLevel logLevel) =>
+			InternalLogger.IsEnabled(logLevel);
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+		{
+			InternalLogger.Log(logLevel, eventId, state, exception, formatter);
+			s_list.Add(formatter(state, exception));
+		}
+
+		public static IEnumerable<string> GetLogMessages() => s_list;
+	}
+
+	/// <summary>
+	/// Creates a mock of the HttpClientFactory that returns a HttpClient that returns the given message.
+	/// </summary>
+	/// <param name="message">The response message to return.</param>
+	/// <param name="numberOfFailuresBeforeOk">The number of failures before returning the response.</param>
+	/// <param name="shouldThrowException">Whether the HttpClient should throw an exception.</param>
+	/// <returns>The Http Client factory mock.</returns>
+	internal static Mock<IHttpClientFactory> GetHttpClientFactoryMock(
+		HttpResponseMessage message,
+		int? numberOfFailuresBeforeOk = null,
+		bool? shouldThrowException = false)
+	{
+		HttpMessageHandler messageHandler =
+			(shouldThrowException, numberOfFailuresBeforeOk) switch
+			{
+				(true, _) => new MockedHttpExceptionMessageHandler(message),
+				(_, null) => new MockedHttpMessageHandler(message),
+				(_, int n) => new MockedRepeatedErrorsHttpMessageHandler(message, n)
+			};
+
+		HttpClient httpClientMock = new(messageHandler);
+
+		Mock<IHttpClientFactory> mock = new();
+		mock.Setup(f => f.CreateClient(It.IsAny<string>()))
+			.Returns(httpClientMock);
+
+		return mock;
+	}
+
+	/// <summary>
+	/// Returns a new HttpRequestMessage instance for mocking HTTP calls.
+	/// </summary>
+	/// <param name="uri">The URI.</param>
+	/// <returns>The Request message</returns>
+	internal static HttpRequestMessage GetHttpRequestMessageMock(string? uri = null) =>
+		new(HttpMethod.Get, uri ?? "https://something.com/");
+
+	/// <summary>
+	/// Creates a new response message.
+	/// </summary>
+	/// <param name="statusCode">The response status code.</param>
+	/// <param name="message">The response raw body string.</param>
+	/// <returns>The response.</returns>
+	internal static HttpResponseMessage GetHttpResponseMessageMock(HttpStatusCode statusCode, string message) =>
+		new(statusCode)
+		{
+			Content = new StringContent(message)
+		};
+
+	public const int SfServiceMockLocalPort = 80;
+	public const string SfServiceMockLocalHost = "localhost";
+
+
+	/// <summary>
+	/// Creates the local SF service info mock.
+	/// </summary>
+	internal static void SetLocalServiceInfo()
+	{
+		const string PublishAddressEvnVariableName = "Fabric_NodeIPOrFQDN";
+		const string EndpointPortEvnVariableSuffix = "Fabric_Endpoint_";
+
+		Environment.SetEnvironmentVariable($"{EndpointPortEvnVariableSuffix}ServiceHttpEndpoint", "80", EnvironmentVariableTarget.Process);
+		Environment.SetEnvironmentVariable(PublishAddressEvnVariableName, "localhost", EnvironmentVariableTarget.Process);
+	}
+}
+
+internal class MockedHttpMessageHandler : HttpMessageHandler
+{
+	private readonly HttpResponseMessage m_response;
+
+	public MockedHttpMessageHandler(HttpResponseMessage response)
+	{
+		m_response = response;
+	}
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		Task.FromResult(m_response);
+}
+
+/// <summary>
+/// Returns 500 for a given number of times before returning the given response.
+/// The pattern is recursive, so after returning an OK response, it returns an originally given number of 500 responses.
+/// </summary>
+internal class MockedRepeatedErrorsHttpMessageHandler : HttpMessageHandler
+{
+	private readonly HttpResponseMessage m_response;
+	private readonly int m_failureTimes;
+	private int m_failureCount;
+
+	public MockedRepeatedErrorsHttpMessageHandler(HttpResponseMessage response, int failureTime)
+	{
+		m_response = response;
+		m_failureTimes = failureTime;
+		m_failureCount = failureTime;
+	}
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		if (m_failureCount > 0)
+		{
+			m_failureCount--;
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+		}
+
+		m_failureCount = m_failureTimes;
+		return Task.FromResult(m_response);
+	}
+}
+
+internal class MockedHttpExceptionMessageHandler : HttpMessageHandler
+{
+	private readonly HttpResponseMessage m_response;
+
+	public MockedHttpExceptionMessageHandler(HttpResponseMessage response)
+	{
+		m_response = response;
+	}
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		// If the status code is OK, the client won't throw an exception.
+		m_response.StatusCode == HttpStatusCode.OK
+			? Task.FromResult(m_response)
+#if NET5_0_OR_GREATER
+			: throw new HttpRequestException("An exception was raised", null, m_response.StatusCode);
+#else
+			: throw new HttpRequestException("An exception was raised", null);
+#endif
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables;
+
+[TestClass]
+public class HttpEndpointHealthCheckTests
+{
+	private static readonly ActivitySource s_activitySource = new(nameof(ObservableHealthCheckTests));
+
+	private static readonly ILogger s_logger = NullLogger.Instance;
+
+	[TestMethod]
+	[DataRow(HttpStatusCode.OK, HealthStatus.Healthy)]
+	[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Unhealthy)]
+	[DataRow(HttpStatusCode.NotFound, HealthStatus.Unhealthy)]
+	[DataRow(HttpStatusCode.Forbidden, HealthStatus.Unhealthy)]
+	[DataRow(HttpStatusCode.Unauthorized, HealthStatus.Unhealthy)]
+	public async Task HttpEndpointHealthCheck_OkResponseChecker_ShouldReturnHealthy_WhenEndpointReturnsSuccessStatusCode(
+		HttpStatusCode responseStatusCode,
+		HealthStatus expectedHealthStatus)
+	{
+		HttpRequestMessage request = HealthCheckTestHelpers.GetHttpRequestMessageMock();
+		HttpResponseMessage response = HealthCheckTestHelpers.GetHttpResponseMessageMock(responseStatusCode, string.Empty);
+		Mock<IHttpClientFactory> httpClientFactoryMock = HealthCheckTestHelpers.GetHttpClientFactoryMock(response);
+
+		HealthChecks.Composables.HttpEndpointHealthCheck healthCheck = new(
+			httpClientFactoryMock.Object,
+			() => request,
+			(ctx, r, _) => HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(ctx, r),
+			s_activitySource);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult result = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(expectedHealthStatus, result.Status);
+	}
+
+	[TestMethod]
+	[DataRow(HttpStatusCode.OK, HealthStatus.Healthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	[DataRow(HttpStatusCode.BadRequest, HealthStatus.Healthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Unhealthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	[DataRow(HttpStatusCode.NotFound, HealthStatus.Unhealthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	[DataRow(HttpStatusCode.Forbidden, HealthStatus.Unhealthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	[DataRow(HttpStatusCode.Unauthorized, HealthStatus.Unhealthy, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest })]
+	public async Task HttpEndpointHealthCheck_OkResponseChecker_ShouldReturnHealthy_WhenEndpointReturnsAllowedStatusCode(
+		HttpStatusCode responseStatusCode,
+		HealthStatus expectedHealthStatus,
+		HttpStatusCode[] allowedStatusCodes)
+	{
+		HttpRequestMessage request = HealthCheckTestHelpers.GetHttpRequestMessageMock();
+		HttpResponseMessage response = HealthCheckTestHelpers.GetHttpResponseMessageMock(responseStatusCode, string.Empty);
+		Mock<IHttpClientFactory> httpClientFactoryMock = HealthCheckTestHelpers.GetHttpClientFactoryMock(response);
+		HealthCheckParameters parameters = new();
+
+		HealthChecks.Composables.HttpEndpointHealthCheck healthCheck = new(
+			httpClientFactoryMock.Object,
+			() => request,
+			(ctx, r, _) => HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(ctx, r, allowedStatusCodes),
+			s_activitySource);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult result = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(expectedHealthStatus, result.Status);
+	}
+
+	[TestMethod]
+	[DataRow("expected body", "expected body", HealthStatus.Healthy)]
+	[DataRow("expected body", "returned body", HealthStatus.Unhealthy)]
+	public async Task HttpEndpointHealthCheck_CustomResponseChecker_ShouldReturnHealthy_WhenEndpointReturnsSuccessStatusCode(
+		string expectedBody,
+		string responseBody,
+		HealthStatus expectedHealthStatus)
+	{
+		HttpRequestMessage request = HealthCheckTestHelpers.GetHttpRequestMessageMock();
+		HttpResponseMessage response = HealthCheckTestHelpers.GetHttpResponseMessageMock(HttpStatusCode.OK, responseBody);
+		Mock<IHttpClientFactory> httpClientFactoryMock = HealthCheckTestHelpers.GetHttpClientFactoryMock(response);
+
+		HealthChecks.Composables.HttpEndpointHealthCheck healthCheck = new(
+			httpClientFactoryMock.Object,
+			() => request,
+			new CustomHealthCheckResponseChecker(expectedBody).CheckResponseAsync,
+			s_activitySource);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult result = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(expectedHealthStatus, result.Status);
+	}
+}
+
+internal class CustomHealthCheckResponseChecker
+{
+	private string m_expectedResponse = string.Empty;
+
+	public CustomHealthCheckResponseChecker(string expectedResponse)
+	{
+		m_expectedResponse = expectedResponse;
+	}
+
+	public async Task<HealthCheckResult> CheckResponseAsync(
+		HealthCheckContext context,
+		HttpResponseMessage response,
+		CancellationToken cancellationToken)
+	{
+#if NET5_0_OR_GREATER
+		string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
+		string responseContent = await response.Content.ReadAsStringAsync();
+#endif
+
+		return responseContent.Equals(m_expectedResponse, StringComparison.InvariantCulture)
+			? HealthCheckResult.Healthy()
+			: HealthCheckResult.Unhealthy();
+	}
+}
+

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpResponseValidatorsTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpResponseValidatorsTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables
+{
+	[TestClass]
+	public class HttpResponseValidatorsTests
+	{
+		[TestMethod]
+		public async Task CheckResponseStatusCodeAsync_ReturnsHealthy_WhenResponseIsHealthy()
+		{
+			Mock<IHealthCheck> mockedHealthCheck = new();
+			HealthCheckContext context = HealthCheckTestHelpers.GetHealthCheckContext(mockedHealthCheck.Object);
+			HttpResponseMessage response = new(HttpStatusCode.OK);
+
+			HealthCheckResult result = await HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response);
+
+			Assert.AreEqual(HealthStatus.Healthy, result.Status);
+		}
+
+		[TestMethod]
+		[DataRow(HealthStatus.Unhealthy)]
+		[DataRow(HealthStatus.Degraded)]
+		public async Task CheckResponseStatusCodeAsync_ReturnsHealthy_WhenStatusCodeIsAmongSpecifiedOnes(HealthStatus faultStatus)
+		{
+			Mock<IHealthCheck> mockedHealthCheck = new();
+			HttpStatusCode[] allowedStatusCodes = new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest };
+			HealthCheckContext context = HealthCheckTestHelpers.GetHealthCheckContext(mockedHealthCheck.Object, faultStatus);
+			HttpResponseMessage response1 = new(HttpStatusCode.OK);
+			HttpResponseMessage response2 = new(HttpStatusCode.BadRequest);
+			HttpResponseMessage response3 = new(HttpStatusCode.InternalServerError);
+
+			HealthCheckResult result1 = await HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response1, allowedStatusCodes);
+			HealthCheckResult result2 = await HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response2, allowedStatusCodes);
+			HealthCheckResult result3 = await HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response3, allowedStatusCodes);
+
+			Assert.AreEqual(HealthStatus.Healthy, result1.Status);
+			Assert.AreEqual(HealthStatus.Healthy, result2.Status);
+			Assert.AreEqual(faultStatus, result3.Status);
+		}
+
+		[TestMethod]
+		[DataRow(HttpStatusCode.BadRequest, HealthStatus.Unhealthy)]
+		[DataRow(HttpStatusCode.Forbidden, HealthStatus.Unhealthy)]
+		[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Unhealthy)]
+		[DataRow(HttpStatusCode.Unauthorized, HealthStatus.Unhealthy)]
+		[DataRow(HttpStatusCode.BadRequest, HealthStatus.Degraded)]
+		[DataRow(HttpStatusCode.Forbidden, HealthStatus.Degraded)]
+		[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Degraded)]
+		[DataRow(HttpStatusCode.Unauthorized, HealthStatus.Degraded)]
+		public async Task OkHttpResponseValidator_ReturnsHealthy_WhenResponseIsHealthy(
+			HttpStatusCode responseStatusCode,
+			HealthStatus registeredHealthStatus)
+		{
+			Mock<IHealthCheck> mockedHealthCheck = new();
+			HealthCheckContext context = HealthCheckTestHelpers.GetHealthCheckContext(mockedHealthCheck.Object, registeredHealthStatus);
+			HttpResponseMessage response = new(responseStatusCode);
+
+			HealthCheckResult result = await HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response);
+
+			Assert.AreEqual(registeredHealthStatus, result.Status);
+			Assert.IsTrue(result.Description?.Contains(responseStatusCode.ToString()) == true);
+		}
+	}
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/ObservableHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/ObservableHealthCheckTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composables;
+
+[TestClass]
+public class ObservableHealthCheckTests
+{
+	private static readonly ActivitySource s_activitySource = new(nameof(ObservableHealthCheckTests));
+
+	private static readonly ILogger s_logger = NullLogger.Instance;
+
+	[TestMethod]
+	[DataRow(HealthStatus.Healthy, HealthStatus.Degraded, HealthStatus.Healthy)]
+	[DataRow(HealthStatus.Healthy, HealthStatus.Unhealthy, HealthStatus.Healthy)]
+	[DataRow(HealthStatus.Unhealthy, HealthStatus.Degraded, HealthStatus.Degraded)]
+	[DataRow(HealthStatus.Unhealthy, HealthStatus.Unhealthy, HealthStatus.Unhealthy)]
+	[DataRow(HealthStatus.Degraded, HealthStatus.Degraded, HealthStatus.Degraded)]
+	[DataRow(HealthStatus.Degraded, HealthStatus.Unhealthy, HealthStatus.Unhealthy)]
+	public async Task MonitorHealthCheck_ShouldReturnGivenState_WhenHealthCheckHasGivenStatus(
+		HealthStatus healthStatus,
+		HealthStatus registeredFailureStatus,
+		HealthStatus expectedStatus)
+	{
+		Mock<IHealthCheck> healthCheckMock = new();
+		healthCheckMock.Setup(hc => hc.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new HealthCheckResult(healthStatus));
+
+		ObservableHealthCheck monitorHealthCheck = new(new(), healthCheckMock.Object, s_activitySource, s_logger);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult result = await monitorHealthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(monitorHealthCheck, registeredFailureStatus),
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(expectedStatus, result.Status);
+	}
+
+	[TestMethod]
+	public async Task MonitorHealthCheck_ShouldReturnUnhealthy_WhenHealthCheckThrowsException()
+	{
+		HealthCheckTestHelpers.InMemoryLogger logger = HealthCheckTestHelpers.GetLoggerInstance();
+
+		const string ExceptionMessage = "Exception message";
+		Mock<IHealthCheck> healthCheckMock = new();
+		healthCheckMock.Setup(hc => hc.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException(ExceptionMessage));
+
+		ObservableHealthCheck monitorHealthCheck = new(new(), healthCheckMock.Object, s_activitySource, logger);
+
+		CancellationTokenSource source = new();
+		HealthCheckContext context = HealthCheckTestHelpers.GetHealthCheckContext(monitorHealthCheck);
+
+		HealthCheckResult result = await monitorHealthCheck.CheckHealthAsync(
+			context,
+			source.Token);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(context.Registration.FailureStatus, result.Status);
+	}
+}

--- a/tests/Diagnostics.HealthChecks.UnitTests/HealthChecksBuilderExtensionsTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/HealthChecksBuilderExtensionsTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 	{
 		[DataTestMethod]
 		[DynamicData(nameof(GetHeaders), DynamicDataSourceType.Method)]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public void AddServiceFabricHealthChecks_RegisterPublisherAndChecks(IReadOnlyDictionary<string, IEnumerable<string>> headers)
 		{
 			string checkName = "MockHttpCheck";
@@ -56,6 +57,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 
 		[DataTestMethod]
 		[DataRow("https://localhost")]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public void AddServiceFabricHealthChecks_InvalidPath_ThrowException(string path)
 		{
 			string endpoitName = "EndpointName";
@@ -65,6 +67,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public void AddServiceFabricHealthChecks_HeaderKeyIsWhiteSpace_ThrowException()
 		{
 			string endpoitName = "EndpointName";
@@ -77,12 +80,14 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 					}));
 		}
 
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		private IHealthChecksBuilder GetBuilder() =>
 			new ServiceCollection()
 				.AddSingleton(new ActivitySource(nameof(HealthChecksBuilderExtensionsTests)))
 				.AddSingleton(new Mock<IAccessor<IServicePartition>>().Object)
 				.AddServiceFabricHealthChecks();
 
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		private HttpHealthCheckParameters GetParameters(IServiceProvider provider, string checkName)
 		{
 			IOptions<HealthCheckServiceOptions> options = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();

--- a/tests/Diagnostics.HealthChecks.UnitTests/HttpEndpointHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/HttpEndpointHealthCheckTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 	public class HttpEndpointHealthCheckTests
 	{
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task CheckHealthAsync_WhenExpectedStatus_ReturnsHealthy()
 		{
 			string contentText = nameof(CheckHealthAsync_WhenExpectedStatus_ReturnsHealthy);
@@ -45,6 +46,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task CheckHealthAsync_WhenWrongStatusAndDefaultRegistrationFailureStatus_ReturnsUnhealthy()
 		{
 			string contentText = nameof(CheckHealthAsync_WhenWrongStatusAndDefaultRegistrationFailureStatus_ReturnsUnhealthy);
@@ -69,6 +71,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task CheckHealthAsync_WhenWrongStatusAndExplicitRegistrationFailureStatus_ReturnsRegistrationFailureStatus()
 		{
 			string contentText = nameof(CheckHealthAsync_WhenWrongStatusAndExplicitRegistrationFailureStatus_ReturnsRegistrationFailureStatus);
@@ -93,6 +96,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public async Task CheckHealthAsync_WithAdditionalCheck_ReturnsOverridenResult()
 		{
 			string contentText = nameof(CheckHealthAsync_WithAdditionalCheck_ReturnsOverridenResult);
@@ -126,6 +130,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			CollectionAssert.AreEquivalent(reportData, result.Data.ToArray(), "Provided result should have proper data");
 		}
 
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		private async Task<(MockClient, HealthCheckResult)> RunHealthCheckAsync(
 			HttpHealthCheckParameters parameters, HttpResponseMessage response, HealthStatus failureStatus = HealthStatus.Unhealthy)
 		{

--- a/tests/Diagnostics.HealthChecks.UnitTests/ServiceCollectionExtensions.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/ServiceCollectionExtensions.cs
@@ -73,8 +73,8 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 
 		public class MockCheck : IHealthCheck
 		{
-			public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken) =>
-				Task.FromResult(HealthCheckResult.Healthy());
+			public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken) =>
+				await Task.FromResult(HealthCheckResult.Healthy());
 		}
 	}
 }

--- a/tests/Diagnostics.HealthChecks.UnitTests/ServiceCollectionExtensions.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		}
 
 		[TestMethod]
+		[Obsolete("The health check implementation based on AbstractHealthCheck is obsolete.")]
 		public void AddServiceFabricHealthChecks_RegisterPublisherAndChecks()
 		{
 			string checkName = "MockCheck";


### PR DESCRIPTION
## Summary

Implements the porting of the composable Health Check classes implementation for .NET Health Checks.

Each composable class implements a different behaviour, specialising in only one responsibility, thus granting more granular maintenance and flexibility compared to an implementation that leverages a chain of inheritance. For instance, using the composition it will be theoretically possible to invert the wrapping order of the classes, or remove a composable class in the middle of the "chain".

These composable classes are the following:

- **`ObserverHealthCheck`**: this is the outermost wrapper, as it implements the exception handling and the activity definition.
- **`StartupHealthCheck`**: implements the behaviour by which the health check is executed only at start-up time, to prevent the deployment of a faulty version of the application.
- **`HttpEndpointHealthCheck`**: this class is the core of the HTTP Endpoint health checks, in that it performs the call to the endpoints that must be checked by the active monitoring and offers extension by the injection of a `IHealthCheckResponseChecker` interface, which exposes a method that checks the response returned from the HTTP call.

There are two example of different composition strategies in the project, both pointing to the load feedback endpoint:

#### Liveness Health Check
This health checks simply checks whether the related endpoint is reachable, and the request handling should be short circuited by the server, returning 200. This is accomplished by specifying the `MarkAsLivenessCheck` activity marker.
#### Execution Health Check
In this case, the activity marker selected is simply the `HealthCheckActivityMarker`, which marks the activity as belonging to a health check without dictating the short-circuiting of the request by the server. 
This strategy should be used when the execution of the endpoint is equally important as its availability.

The short-circuiting behaviour in the server endpoint has been implemented using the Action Filter -`LivenessCheckActionFilterAttribute`, that checks whether the endpoint current activity (if existent) has been marked accordingly, as mentioned above.

### Implementation details

Another diagnostic package has been created to avoid adding .NET 7 specific dependencies to the project. In particular, the implementation of the activity markers for request short-circuiting and the `LivenessCheckActionFilterAttribute` dependent on ASP.NET Core dependencies have been implemented in the new package.

Another Unit Test project has been created for the same purpose, as the controller endpoint filter implementation is heavily dependent on .NET 7.