### PR TITLE
Reduced the number of obsoletion in the Diagnostics project

### DIFF
--- a/src/Diagnostics.HealthChecks/HealthCheckConstants.cs
+++ b/src/Diagnostics.HealthChecks/HealthCheckConstants.cs
@@ -1,14 +1,19 @@
 ﻿// Copyright (C) Microsoft Corporation. All rights reserved.
 
-namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
 
 /// <summary>
 /// A series of constants used by health checks.
 /// </summary>
-public static class HealthCheckConstants
+internal static class HealthCheckConstants
 {
 	/// <summary>
 	/// The local service default host.
 	/// </summary>
 	public const string LocalServiceDefaultHost = "localhost";
+
+	/// <summary>
+	/// The HTTP client logical name.
+	/// </summary>
+	public const string HttpClientLogicalName = "HttpEndpointHealthCheckHttpClient";
 }

--- a/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 	[Obsolete("The usage of this class is deprecated and will be removed in a later release, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	internal class HttpEndpointHealthCheck : AbstractHealthCheck<HttpHealthCheckParameters>
 	{
-		[Obsolete("This property is deprecated and will be removed in a later release.")]
-		public static string HttpClientLogicalName { get; } = "HttpEndpointHealthCheckHttpClient";
-
 		private readonly IHttpClientFactory m_httpClientFactory;
 
 		public HttpEndpointHealthCheck(

--- a/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks/Internal/HttpEndpointHealthCheck.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 	[Obsolete("The usage of this class is deprecated and will be removed in a later release, please use composable classes in Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables namespace to build health checks.")]
 	internal class HttpEndpointHealthCheck : AbstractHealthCheck<HttpHealthCheckParameters>
 	{
+		[Obsolete("This property is deprecated and will be removed in a later release.")]
 		public static string HttpClientLogicalName { get; } = "HttpEndpointHealthCheckHttpClient";
 
 		private readonly IHttpClientFactory m_httpClientFactory;
@@ -34,7 +35,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		{
 			string checkName = context.Registration.Name;
 
-			HttpClient httpClient = m_httpClientFactory.CreateClient(HttpClientLogicalName);
+			HttpClient httpClient = m_httpClientFactory.CreateClient(HealthCheckConstants.HttpClientLogicalName);
 			HttpResponseMessage? response = await httpClient.SendAsync(CloneRequestMessage(Parameters.RequestMessage), token).ConfigureAwait(false);
 
 			HealthStatus healthStatus = HealthStatus.Unhealthy;

--- a/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/ServiceCollectionExtensions.cs
@@ -21,14 +21,13 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Add dependencies for a publisher
 		/// </summary>
-		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IServiceCollection AddPublisherDependencies(this IServiceCollection serviceCollection)
 		{
 			// HttpClient registration only needed for HttpEndpointHealthCheck.
 			// It add added here instead of AddHttpEndpointCheck method to avoid creating new configuration each time new health check added.
 			// It would be nice to register this HttpClient configuration once and only if HttpEndpointCheck used.
 			serviceCollection
-				.AddHttpClient(HttpEndpointHealthCheck.HttpClientLogicalName)
+				.AddHttpClient(HealthCheckConstants.HttpClientLogicalName)
 				.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
 				{
 					AllowAutoRedirect = false,
@@ -43,14 +42,12 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Register publisher for processing health check results directly to replicas
 		/// </summary>
-		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddServiceFabricHealthChecks(this IServiceCollection serviceCollection) =>
 			serviceCollection.AddOmexHealthCheckDependencies<ServiceContextHealthStatusSender>();
 
 		/// <summary>
 		/// Register publisher for processing health check results directly to nodes using REST api
 		/// </summary>
-		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		public static IHealthChecksBuilder AddRestHealthChecksPublisher(this IServiceCollection serviceCollection) =>
 			serviceCollection
 				.AddServiceFabricClient()
@@ -59,8 +56,6 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks
 		/// <summary>
 		/// Register publisher for processing health check results
 		/// </summary>
-
-		[Obsolete("This method is deprecated and will be removed in a later release, please use HealthCheckComposablesExtensions class extension methods to compose health checks.")]
 		private static IHealthChecksBuilder AddOmexHealthCheckDependencies<TStatusSender>(this IServiceCollection serviceCollection)
 				where TStatusSender : class, IHealthStatusSender
 		{

--- a/tests/Diagnostics.HealthChecks.UnitTests/HttpEndpointHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/HttpEndpointHealthCheckTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 			Mock<IHttpClientFactory> factoryMock = new();
 			MockClient clientMock = new(response);
 
-			factoryMock.Setup(f => f.CreateClient(HttpEndpointHealthCheck.HttpClientLogicalName))
+			factoryMock.Setup(f => f.CreateClient(HealthCheckConstants.HttpClientLogicalName))
 				.Returns(clientMock);
 
 			HttpEndpointHealthCheck healthCheck = new(


### PR DESCRIPTION
## Summary

The changes in this PR are a follow up of the ones in the [previous PR](https://github.com/microsoft/Omex/pull/591).

To let the teams consuming the Diagnostics package know of the new Health Checks implementation, a number of extension methods defined in the package were marked as `Obsolete`: by refactoring the constants in the project, the number of those methods are reduced, allowing client teams to reduce the amount of refactoring to implement in their projects.