### PR TITLE
[HealthChecks] Removing references to legacy MVC packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,6 @@
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="4.7.0" />

--- a/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
+++ b/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
@@ -12,9 +12,9 @@
     <PackageTags>Microsoft;Omex;Extensions;HealthChecks;AspNetCore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <ProjectReference Include="..\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
   <ItemGroup Condition="!$(IsNetCore)">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,5 @@
     <ProjectReference Include="..\..\src\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />
     <ProjectReference Include="..\Abstractions.UnitTests\Microsoft.Omex.Extensions.Abstractions.UnitTests.csproj" />
     <ProjectReference Include="..\Diagnostics.HealthChecks.UnitTests\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

In the .NET 7 Health Check specific package, a reference to legacy MVC packages was added in order to create new Action Filters for Controller Endpoints. The reference has been substituted to modern standards. This will remove a dependency to deprecated packages.