### PR TITLE
Updating devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] .NET version: 5.0, 3.1, 2.1
 ARG VARIANT="7.0"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:dev-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 
 # [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT="7.0.400"
+ARG VARIANT="7.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 
 # [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT="7.0"
+ARG VARIANT="7.0.400"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,16 +3,20 @@
 {
 	"name": "C# (.NET)",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-dotnettools.csharp"
-	],
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-dotnettools.csdevkit"
+			]
+		}
+	},
 
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
## Summary

Upgrades the configuration for the dev container in the repo to solve warnings related to JSON properties not corresponding to the schema.

The Dockerfile base image has been updated to support the latest .NET 7.0.400 SDK. A complete list of images to use in Codespace can be found [here](https://mcr.microsoft.com/en-us/product/devcontainers/dotnet/tags).

It requires the C# Dev Kit extension for Visual Studio Code.

## Test Screenshots

The dev container starts directly from the activation button:

![image](https://github.com/microsoft/Omex/assets/25101798/190114d2-a02a-4d73-b4e6-c20d19131776)

The image specified in the Dockerfile has the correct dotnet version, with the right extensions automatically installed:

![image](https://github.com/microsoft/Omex/assets/25101798/e00152ad-2861-4c47-a0e6-54b02c460964)

The extensions allow the new Solution Explorer view in VSCode directly on the browser:

![image](https://github.com/microsoft/Omex/assets/25101798/fbc34819-52cf-4895-b023-9e15151c8d04)

The dev container generated in Codespace is still available afterwards:

![image](https://github.com/microsoft/Omex/assets/25101798/e0864657-a451-4c37-8aaf-089cbe4e70b5)
