### PR TITLE
Enabled options to disable Omex telemetry via config

### DIFF
--- a/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
+++ b/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
@@ -12,6 +12,7 @@
     <PackageTags>Microsoft;Omex;Extensions;Activities</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />

--- a/src/Activities/Option/ActivityOption.cs
+++ b/src/Activities/Option/ActivityOption.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Omex.Extensions.Activities
 	/// <summary>
 	/// Monitoring option
 	/// </summary>
-	public class ActivityOption
+	internal class ActivityOption
 	{
 		/// <summary>
 		/// Path to the setting

--- a/src/Activities/ServiceCollectionExtensions.cs
+++ b/src/Activities/ServiceCollectionExtensions.cs
@@ -45,7 +45,8 @@ namespace Microsoft.Extensions.DependencyInjection
 			serviceCollection
 				.AddOptions<ActivityOption>()
 				.BindConfiguration(ActivityOption.MonitoringPath)
-				.ValidateDataAnnotations();
+				.ValidateDataAnnotations()
+				.ValidateOnStart();
 
 			serviceCollection.TryAddSingleton<IActivityListenerConfigurator, DefaultActivityListenerConfigurator>();
 			serviceCollection.TryAddSingleton(p => new ActivitySource(ActivitySourceName, ActivitySourceVersion));

--- a/src/Hosting.Services/HostBuilderExtensions.cs
+++ b/src/Hosting.Services/HostBuilderExtensions.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 				builderAction(new ServiceFabricHostBuilder<TService, TContext>(builder));
 
 				IHost host = builder
-					.ConfigureLogging(builder => builder.AddOmexLogging())
 					.ConfigureServices((context, collection) =>
 					{
 						collection
@@ -102,6 +101,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 						options.ValidateOnBuild = true;
 						options.ValidateScopes = true;
 					})
+					.ConfigureLogging(builder => builder.AddOmexLogging())
 					.Build();
 
 				InitializationLogger.LogInitializationSucceed(serviceNameForLogging);

--- a/src/Hosting.Services/HostBuilderExtensions.cs
+++ b/src/Hosting.Services/HostBuilderExtensions.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services
 				builderAction(new ServiceFabricHostBuilder<TService, TContext>(builder));
 
 				IHost host = builder
+					.ConfigureLogging(builder => builder.AddOmexLogging())
 					.ConfigureServices((context, collection) =>
 					{
 						collection

--- a/src/Logging/Internal/OmexLoggerProvider.cs
+++ b/src/Logging/Internal/OmexLoggerProvider.cs
@@ -3,46 +3,35 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Logging.Replayable;
 using Microsoft.Omex.Extensions.Logging.Scrubbing;
 
 namespace Microsoft.Omex.Extensions.Logging
 {
+	[ProviderAlias("Omex")]
 	internal class OmexLoggerProvider : ILoggerProvider, ISupportExternalScope
 	{
 		public OmexLoggerProvider(
-			IOptions<OmexLoggingOptions> options,
 			ILogEventSender logsEventSender,
 			IExternalScopeProvider defaultExternalScopeProvider,
 			IEnumerable<ILogScrubbingRule> textScrubbers,
 			ILogEventReplayer? replayer = null)
 		{
-			m_options = options;
 			m_logsEventSender = logsEventSender;
 			m_defaultExternalScopeProvider = defaultExternalScopeProvider;
 			m_textScrubbers = textScrubbers;
 			m_replayer = replayer;
 		}
 
-		public ILogger CreateLogger(string categoryName)
-		{
-			if (m_options.Value.Enabled)
-			{
-				return new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
-			}
+		public ILogger CreateLogger(string categoryName) =>
+			return new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
 
-			return NullLogger.Instance;
-		}
-		
 		public void Dispose() { }
 
 		public void SetScopeProvider(IExternalScopeProvider scopeProvider) => m_externalScopeProvider = scopeProvider;
 
 		private IExternalScopeProvider? m_externalScopeProvider;
 
-		private readonly IOptions<OmexLoggingOptions> m_options;
 		private readonly ILogEventSender m_logsEventSender;
 		private readonly IExternalScopeProvider m_defaultExternalScopeProvider;
 		private readonly IEnumerable<ILogScrubbingRule> m_textScrubbers;

--- a/src/Logging/Internal/OmexLoggerProvider.cs
+++ b/src/Logging/Internal/OmexLoggerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		}
 
 		public ILogger CreateLogger(string categoryName) =>
-			return new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
+			new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
 
 		public void Dispose() { }
 

--- a/src/Logging/Internal/OmexLoggerProvider.cs
+++ b/src/Logging/Internal/OmexLoggerProvider.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Logging.Replayable;
 using Microsoft.Omex.Extensions.Logging.Scrubbing;
 
@@ -11,28 +13,39 @@ namespace Microsoft.Omex.Extensions.Logging
 	internal class OmexLoggerProvider : ILoggerProvider, ISupportExternalScope
 	{
 		public OmexLoggerProvider(
+			IOptions<OmexLoggingOptions> options,
 			ILogEventSender logsEventSender,
 			IExternalScopeProvider defaultExternalScopeProvider,
 			IEnumerable<ILogScrubbingRule> textScrubbers,
 			ILogEventReplayer? replayer = null)
 		{
+			m_options = options;
 			m_logsEventSender = logsEventSender;
 			m_defaultExternalScopeProvider = defaultExternalScopeProvider;
-			m_replayer = replayer;
 			m_textScrubbers = textScrubbers;
+			m_replayer = replayer;
 		}
 
-		public ILogger CreateLogger(string categoryName) =>
-			new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
+		public ILogger CreateLogger(string categoryName)
+		{
+			if (m_options.Value.Enabled)
+			{
+				return new OmexLogger(m_logsEventSender, m_externalScopeProvider ?? m_defaultExternalScopeProvider, m_textScrubbers, categoryName, m_replayer);
+			}
 
+			return NullLogger.Instance;
+		}
+		
 		public void Dispose() { }
 
 		public void SetScopeProvider(IExternalScopeProvider scopeProvider) => m_externalScopeProvider = scopeProvider;
 
 		private IExternalScopeProvider? m_externalScopeProvider;
+
+		private readonly IOptions<OmexLoggingOptions> m_options;
+		private readonly ILogEventSender m_logsEventSender;
 		private readonly IExternalScopeProvider m_defaultExternalScopeProvider;
 		private readonly IEnumerable<ILogScrubbingRule> m_textScrubbers;
 		private readonly ILogEventReplayer? m_replayer;
-		private readonly ILogEventSender m_logsEventSender;
 	}
 }

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -11,7 +11,9 @@
     <PackageTags>Microsoft;Omex;Extensions;Logging</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -11,9 +11,7 @@
     <PackageTags>Microsoft;Omex;Extensions;Logging</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Abstractions\Microsoft.Omex.Extensions.Abstractions.csproj" />

--- a/src/Logging/OmexLoggingOptions.cs
+++ b/src/Logging/OmexLoggingOptions.cs
@@ -9,16 +9,6 @@ namespace Microsoft.Omex.Extensions.Logging
 	internal class OmexLoggingOptions
 	{
 		/// <summary>
-		/// Default configuration section to bind these options.
-		/// </summary>
-		public const string DefaultConfigurationSection = "OmexLogging";
-
-		/// <summary>
-		/// If false, OmexLoggerProvider returns NullLogger instead of OmexLogger.
-		/// </summary>
-		public bool Enabled { get; set; } = true;
-
-		/// <summary>
 		/// Should logs wrapped by the Activity be stored and replayed at a higher severity, in the event of an error.
 		/// Setting this to true will impact the performance of logging
 		/// </summary>

--- a/src/Logging/OmexLoggingOptions.cs
+++ b/src/Logging/OmexLoggingOptions.cs
@@ -6,8 +6,18 @@ namespace Microsoft.Omex.Extensions.Logging
 	/// <summary>
 	/// Options for Omex logger
 	/// </summary>
-	public class OmexLoggingOptions
+	internal class OmexLoggingOptions
 	{
+		/// <summary>
+		/// Default configuration section to bind these options.
+		/// </summary>
+		public const string DefaultConfigurationSection = "OmexLogging";
+
+		/// <summary>
+		/// If false, OmexLoggerProvider returns NullLogger instead of OmexLogger.
+		/// </summary>
+		public bool Enabled { get; set; } = true;
+
 		/// <summary>
 		/// Should logs wrapped by the Activity be stored and replayed at a higher severity, in the event of an error.
 		/// Setting this to true will impact the performance of logging

--- a/src/Logging/ServiceCollectionExtensions.cs
+++ b/src/Logging/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Omex.Extensions.Abstractions.Activities.Processing;
 using Microsoft.Omex.Extensions.Abstractions.ExecutionContext;
 using Microsoft.Omex.Extensions.Logging.Replayable;
@@ -31,6 +32,7 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <param name="builder">The extension method argument</param>
 		public static ILoggingBuilder AddOmexLogging(this ILoggingBuilder builder)
 		{
+			builder.AddConfiguration();
 			builder.Services.AddOmexLogging();
 			return builder;
 		}
@@ -42,14 +44,6 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained</returns>
 		public static IServiceCollection AddOmexLogging(this IServiceCollection serviceCollection)
 		{
-			serviceCollection
-				.AddOptions<OmexLoggingOptions>()
-				.BindConfiguration(OmexLoggingOptions.DefaultConfigurationSection)
-				.ValidateDataAnnotations()
-				.ValidateOnStart();
-
-			serviceCollection.AddLogging();
-
 			serviceCollection.TryAddTransient<IServiceContext, EmptyServiceContext>();
 			serviceCollection.TryAddTransient<IExecutionContext, BaseExecutionContext>();
 			serviceCollection.TryAddTransient<IExternalScopeProvider, LoggerExternalScopeProvider>();

--- a/src/Logging/ServiceCollectionExtensions.cs
+++ b/src/Logging/ServiceCollectionExtensions.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained</returns>
 		public static IServiceCollection AddOmexLogging(this IServiceCollection serviceCollection)
 		{
+			serviceCollection
+				.AddOptions<OmexLoggingOptions>()
+				.BindConfiguration(OmexLoggingOptions.DefaultConfigurationSection)
+				.ValidateDataAnnotations()
+				.ValidateOnStart();
+
 			serviceCollection.AddLogging();
 
 			serviceCollection.TryAddTransient<IServiceContext, EmptyServiceContext>();

--- a/src/Logging/ServiceCollectionExtensions.cs
+++ b/src/Logging/ServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Omex.Extensions.Logging
 		/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained</returns>
 		public static IServiceCollection AddOmexLogging(this IServiceCollection serviceCollection)
 		{
+			serviceCollection.AddLogging();
+
 			serviceCollection.TryAddTransient<IServiceContext, EmptyServiceContext>();
 			serviceCollection.TryAddTransient<IExecutionContext, BaseExecutionContext>();
 			serviceCollection.TryAddTransient<IExternalScopeProvider, LoggerExternalScopeProvider>();

--- a/tests/Activities.UnitTests/ServiceCollectionTests.cs
+++ b/tests/Activities.UnitTests/ServiceCollectionTests.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 		{
 			Type[] types = GetRegisteredServices<IHostedService>();
 
-			Assert.AreEqual(2, types.Length);
 			CollectionAssert.Contains(types, typeof(ActivityListenerInitializerService));
 			CollectionAssert.Contains(types, typeof(DiagnosticsObserversInitializer));
 		}

--- a/tests/Activities.UnitTests/ServiceCollectionTests.cs
+++ b/tests/Activities.UnitTests/ServiceCollectionTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 		}
 
 		[TestMethod]
-		public void AddOmexActivitySource_HostedServicesRegiestered()
+		public void AddOmexActivitySource_HostedServicesRegistered()
 		{
 			Type[] types = GetRegisteredServices<IHostedService>();
 
@@ -47,7 +47,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 			Task task = CreateHost().RunAsync();
 
 			Activity? activity = new ActivitySource("Source")
-				.StartActivity(nameof(AddOmexActivitySource_HostedServicesRegiestered));
+				.StartActivity(nameof(AddOmexActivitySource_HostedServicesRegistered));
 
 			NullableAssert.IsNotNull(activity, "Activity creation enabled after host started");
 		}

--- a/tests/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
+++ b/tests/Hosting.Services.UnitTests/HostBuilderExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 		[DataRow(typeof(IExecutionContext), typeof(ServiceFabricExecutionContext))]
 		[DataRow(typeof(ActivitySource), null)]
 		[DataRow(typeof(ILogger<HostBuilderExtensionsTests>), null)]
-		public void AddOmexServiceFabricDependencies_TypesRegistered(Type typeToResolver, Type? expectedImplementationType)
+		public void AddOmexServiceFabricDependencies_TypesRegistered(Type typeToResolve, Type? expectedImplementationType)
 		{
 			void CheckTypeRegistration<TContext>() where TContext : ServiceContext
 			{
@@ -33,7 +33,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.UnitTests
 					.AddOmexServiceFabricDependencies<TContext>()
 					.AddSingleton(new Mock<IHostEnvironment>().Object)
 					.BuildServiceProvider()
-					.GetService(typeToResolver);
+					.GetService(typeToResolve);
 
 				Assert.IsNotNull(obj, "Failed to resolve for {0}", typeof(TContext));
 


### PR DESCRIPTION
This opens the way to disable Omex telemetry implementations.

OmexLogger can be controlled by standard logging configuration, usually found in appsettings.json. Option class to disable generation of TimedScope metrics from Activities already existed, binding was improved with validation on start.

To disable both logs and activity metrics, put the following in appsettings.json:
```
{
  "Monitoring": {
    "ActivityEventSenderEnabled": false
  },
  "Logging": {
    "Omex": {
      "LogLevel": {
        "Default": "None"
      }
    }
  }
}
```

Initialization logger for now remains enabled, its usage should be reduced first.