### PR TITLE
Remove redundant signing pattern match

### DIFF
--- a/.github/pipelines/omex-github-official.yml
+++ b/.github/pipelines/omex-github-official.yml
@@ -112,7 +112,7 @@ extends:
               inputs:
                 ConnectedServiceName: OmexOpenSourceESRP
                 FolderPath: $(Build.Repository.LocalPath)\bin
-                Pattern: Microsoft.Omex*.dll,Microsoft.Office.Web.OfficeMarketplace*.dll,Microsoft.Omex*.exe
+                Pattern: Microsoft.Omex*.dll,Microsoft.Omex*.exe
                 signConfigType: inlineSignParams
                 inlineOperation: |
                   [


### PR DESCRIPTION
The pattern match for this step is no longer valid.
All Microsoft.Office.Web.OfficeMarketplace libraries were removed from this repo a long time ago.