### PR TITLE
Added URI scheme selection in liveness health checks

### DIFF
--- a/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheck.cs
@@ -46,7 +46,7 @@ internal class EndpointLivenessHealthCheck : IHealthCheck
 	private HttpRequestMessage CreateHttpRequestMessage()
 	{
 		int port = SfConfigurationProvider.GetEndpointPort(m_parameters.EndpointName);
-		UriBuilder uriBuilder = new(Uri.UriSchemeHttp, m_parameters.Host, port, m_parameters.EndpointRelativeUri);
+		UriBuilder uriBuilder = new(m_parameters.UriScheme, m_parameters.Host, port, m_parameters.EndpointRelativeUri);
 		return new HttpRequestMessage(HttpMethod.Get, uriBuilder.Uri);
 	}
 }

--- a/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
@@ -50,6 +50,11 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 	/// The endpoint relative url at which the Service Fabric health check will be reachable.
 	/// </param>
 	/// <param name="host">The host used to perform the health check HTTP call to the service.</param>
+	/// <param name="uriScheme">
+	/// The URI scheme to use to call the endpoint.
+	/// It is highly recommend to use <seealso cref="Uri.UriSchemeHttp"/> and <seealso cref="Uri.UriSchemeHttps"/>
+	/// to pass either value.
+	/// </param>
 	/// <param name="reportData">The report data.</param>
 	public EndpointLivenessHealthCheckParameters(
 		string endpointName,

--- a/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 
@@ -16,6 +17,12 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 	/// The Service Fabric endpoint name, it will be used to fetch the service port.
 	/// </summary>
 	public string EndpointName { get; }
+
+	/// <summary>
+	/// The URI scheme that will be used to query the endpoint.
+	/// The default value will be equa to HTTP.
+	/// </summary>
+	public string UriScheme { get; } = Uri.UriSchemeHttp;
 
 	/// <summary>
 	/// The endpoint relative url at which the Service Fabric health check will be reachable.
@@ -49,6 +56,7 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 		string httpClientLogicalName,
 		string endpointRelativeUrl,
 		string host = "localhost",
+		string? uriScheme = null,
 		params KeyValuePair<string, object>[] reportData)
 		: base(reportData)
 	{
@@ -56,5 +64,6 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 		HttpClientLogicalName = httpClientLogicalName;
 		EndpointRelativeUri = endpointRelativeUrl;
 		Host = host;
+		UriScheme = uriScheme ?? Uri.UriSchemeHttp;
 	}
 }

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -74,6 +74,12 @@ public static class HealthCheckComposablesExtensions
 	/// </param>
 	/// <param name="failureStatus">The status that will be reported if the Health Check fails.</param>
 	/// <param name="host">The service host.</param>
+	/// <param name="uriScheme">
+	/// The URI scheme to use to call the endpoint.
+	/// It is highly recommend to use <seealso cref="Uri.UriSchemeHttp"/> and <seealso cref="Uri.UriSchemeHttps"/>
+	/// to pass either value.
+	/// If not specified, the default value used will be <seealso cref="Uri.UriSchemeHttp"/>.
+	/// </param>
 	/// <param name="reportData">The report data parameters.</param>
 	/// <returns>The Health Check builder.</returns>
 	public static IHealthChecksBuilder AddEndpointHttpHealthCheck(
@@ -84,6 +90,7 @@ public static class HealthCheckComposablesExtensions
 		string httpClientLogicalName,
 		HealthStatus failureStatus = HealthStatus.Unhealthy,
 		string host = "localhost",
+		string? uriScheme = null,
 		params KeyValuePair<string, object>[] reportData)
 	{
 		EndpointLivenessHealthCheckParameters parameters = new(
@@ -91,6 +98,7 @@ public static class HealthCheckComposablesExtensions
 			httpClientLogicalName,
 			relativePath,
 			host,
+			uriScheme: uriScheme,
 			reportData: reportData
 		);
 

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -91,7 +91,7 @@ public static class HealthCheckComposablesExtensions
 			httpClientLogicalName,
 			relativePath,
 			host,
-			reportData
+			reportData: reportData
 		);
 
 		return healthChecksBuilder.AddEndpointHttpHealthCheck(name, failureStatus, parameters);

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthzEndpointHealthCheck.cs
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthzEndpointHealthCheck.cs
@@ -101,4 +101,131 @@ public class HealthzEndpointHealthCheckTests
 			Assert.IsTrue(healthCheckResult.Description?.Contains(returnedStatusCode.ToString(), StringComparison.InvariantCulture));
 		}
 	}
+
+	[TestMethod]
+	public async Task HealthzEndpointHttpHealthCheck_ReturnsCorrectResponseWhenHttpExpected()
+	{
+		EndpointLivenessHealthCheckParameters healthCheckParameters = new(
+			nameof(EndpointLivenessHealthCheck),
+			$"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
+			"healthz");
+
+		HealthCheckTestHelpers.SetLocalServiceInfo();
+		Mock<IHttpClientFactory> httpOnlyClientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
+			HealthCheckTestHelpers.GetHttpResponseMessageMock(HttpStatusCode.OK, "Response is OK."),
+			shouldThrowException: false,
+			requestMatch: request => request.RequestUri?.Scheme == Uri.UriSchemeHttp);
+
+		ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
+
+		IHealthCheck healthCheck = new EndpointLivenessHealthCheck(
+			httpOnlyClientFactory.Object,
+			activitySourceMock,
+			GetLogger<EndpointLivenessHealthCheck>(),
+			healthCheckParameters);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.AreEqual(HealthStatus.Healthy, healthCheckResult.Status);
+	}
+
+	[TestMethod]
+	public async Task HealthzEndpointHttpHealthCheck_ReturnsErrorWhenHttpsExpected()
+	{
+		EndpointLivenessHealthCheckParameters healthCheckParameters = new(
+			nameof(EndpointLivenessHealthCheck),
+			$"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
+			"healthz");
+
+		HealthCheckTestHelpers.SetLocalServiceInfo();
+		Mock<IHttpClientFactory> httpOnlyClientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
+			HealthCheckTestHelpers.GetHttpResponseMessageMock(HttpStatusCode.OK, "Response is OK."),
+			shouldThrowException: false,
+			requestMatch: request => request.RequestUri?.Scheme == Uri.UriSchemeHttps);
+
+		ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
+
+		IHealthCheck healthCheck = new EndpointLivenessHealthCheck(
+			httpOnlyClientFactory.Object,
+			activitySourceMock,
+			GetLogger<EndpointLivenessHealthCheck>(),
+			healthCheckParameters);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.AreEqual(HealthStatus.Unhealthy, healthCheckResult.Status);
+	}
+
+	[TestMethod]
+	public async Task HealthzEndpointHttpHealthCheck_ReturnsCorrectResponseWhenHttpsExpected()
+	{
+		EndpointLivenessHealthCheckParameters healthCheckParameters = new(
+			nameof(EndpointLivenessHealthCheck),
+			$"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
+			"healthz",
+			uriScheme: Uri.UriSchemeHttps);
+
+		HealthCheckTestHelpers.SetLocalServiceInfo();
+		Mock<IHttpClientFactory> httpOnlyClientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
+			HealthCheckTestHelpers.GetHttpResponseMessageMock(HttpStatusCode.OK, "Response is OK."),
+			shouldThrowException: false,
+			requestMatch: request => request.RequestUri?.Scheme == Uri.UriSchemeHttps);
+
+		ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
+
+		IHealthCheck healthCheck = new EndpointLivenessHealthCheck(
+			httpOnlyClientFactory.Object,
+			activitySourceMock,
+			GetLogger<EndpointLivenessHealthCheck>(),
+			healthCheckParameters);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.AreEqual(HealthStatus.Healthy, healthCheckResult.Status);
+	}
+
+	[TestMethod]
+	public async Task HealthzEndpointHttpHealthCheck_ReturnsErrorWhenHttpExpected()
+	{
+		EndpointLivenessHealthCheckParameters healthCheckParameters = new(
+			nameof(EndpointLivenessHealthCheck),
+			$"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
+			"healthz",
+			Uri.UriSchemeHttps);
+
+		HealthCheckTestHelpers.SetLocalServiceInfo();
+		Mock<IHttpClientFactory> httpOnlyClientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
+			HealthCheckTestHelpers.GetHttpResponseMessageMock(HttpStatusCode.OK, "Response is OK."),
+			shouldThrowException: true,
+			requestMatch: request => request.RequestUri?.Scheme == Uri.UriSchemeHttp);
+
+		ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
+
+		IHealthCheck healthCheck = new EndpointLivenessHealthCheck(
+			httpOnlyClientFactory.Object,
+			activitySourceMock,
+			GetLogger<EndpointLivenessHealthCheck>(),
+			healthCheckParameters);
+
+		CancellationTokenSource source = new();
+
+		HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
+			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+			source.Token);
+
+		Assert.AreEqual(HealthStatus.Healthy, healthCheckResult.Status);
+	}
 }
+


### PR DESCRIPTION
# Summary

The liveness health check definition does not offer the capability of customising the endpoint URI scheme. This PR introduces the capability of defining the URI scheme as part of the health check parameters class instance definition offered using the liveness health check extension method `AddEndpointHttpHealthCheck`, specifying the `uriScheme` parameter.

The functionality can be leveraged by the `AddEndpointHttpHealthCheck` method, by specifying the `UriScheme` parameter in the constructor: this parameter will then be used by the underlying health check instance to define the URI schema.