### PR TITLE
Enable Data Contract Serialization for Remoting Exceptions

### DIFF
--- a/src/Hosting.Services.Remoting/HostBuilderExtensions.cs
+++ b/src/Hosting.Services.Remoting/HostBuilderExtensions.cs
@@ -22,10 +22,17 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			this ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> builder,
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
-				where TService : class, IService =>
-					builder
-						.ConfigureServices((_, services) => services.TryAddTransient<TService>())
-						.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
+				where TService : class, IService
+		{
+			if (settings == null)
+			{
+				settings = new FabricTransportRemotingListenerSettings();
+			}
+			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
+			return builder
+				.ConfigureServices((_, services) => services.TryAddTransient<TService>())
+				.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
+		}
 
 		/// <summary>
 		/// Adds remote listener to stateless service
@@ -34,10 +41,17 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			this ServiceFabricHostBuilder<OmexStatelessService, StatelessServiceContext> builder,
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
-				where TService : class, IService =>
-					builder
-						.ConfigureServices((_, services) => services.TryAddTransient<TService>())
-						.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
+				where TService : class, IService
+		{
+			if (settings == null)
+			{
+				settings = new FabricTransportRemotingListenerSettings();
+			}
+			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
+			return builder
+				.ConfigureServices((_, services) => services.TryAddTransient<TService>())
+				.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
+		}
 
 		/// <summary>
 		/// Adds remote listener to stateful service
@@ -64,8 +78,15 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 				Func<IServiceProvider, TService, IService> createService,
 				FabricTransportRemotingListenerSettings? settings = null)
 					where TService : IServiceFabricService<TContext>
-					where TContext : ServiceContext =>
-						builder.AddServiceListener(p =>
-							new GenericRemotingListenerBuilder<TService>(name, p, createService, settings));
+					where TContext : ServiceContext
+		{
+			if (settings == null)
+			{
+				settings = new FabricTransportRemotingListenerSettings();
+			}
+			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
+			return builder.AddServiceListener(p =>
+				new GenericRemotingListenerBuilder<TService>(name, p, createService, settings));
+		}
 	}
 }

--- a/src/Hosting.Services.Remoting/HostBuilderExtensions.cs
+++ b/src/Hosting.Services.Remoting/HostBuilderExtensions.cs
@@ -22,17 +22,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			this ServiceFabricHostBuilder<OmexStatefulService, StatefulServiceContext> builder,
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
-				where TService : class, IService
-		{
-			if (settings == null)
-			{
-				settings = new FabricTransportRemotingListenerSettings();
-			}
-			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
-			return builder
-				.ConfigureServices((_, services) => services.TryAddTransient<TService>())
-				.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
-		}
+				where TService : class, IService =>
+					builder
+						.ConfigureServices((_, services) => services.TryAddTransient<TService>())
+						.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
 
 		/// <summary>
 		/// Adds remote listener to stateless service
@@ -41,17 +34,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			this ServiceFabricHostBuilder<OmexStatelessService, StatelessServiceContext> builder,
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
-				where TService : class, IService
-		{
-			if (settings == null)
-			{
-				settings = new FabricTransportRemotingListenerSettings();
-			}
-			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
-			return builder
-				.ConfigureServices((_, services) => services.TryAddTransient<TService>())
-				.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
-		}
+				where TService : class, IService =>
+					builder
+						.ConfigureServices((_, services) => services.TryAddTransient<TService>())
+						.AddRemotingListener(name, (provider, _) => provider.GetRequiredService<TService>(), settings);
 
 		/// <summary>
 		/// Adds remote listener to stateful service
@@ -78,15 +64,8 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 				Func<IServiceProvider, TService, IService> createService,
 				FabricTransportRemotingListenerSettings? settings = null)
 					where TService : IServiceFabricService<TContext>
-					where TContext : ServiceContext
-		{
-			if (settings == null)
-			{
-				settings = new FabricTransportRemotingListenerSettings();
-			}
-			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
-			return builder.AddServiceListener(p =>
-				new GenericRemotingListenerBuilder<TService>(name, p, createService, settings));
-		}
+					where TContext : ServiceContext =>
+						builder.AddServiceListener(p =>
+							new GenericRemotingListenerBuilder<TService>(name, p, createService, settings));
 	}
 }

--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -29,10 +29,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
 		{
-			if (settings == null)
-			{
-				settings = new FabricTransportRemotingListenerSettings();
-			}
+			settings = settings ?? FabricTransportRemotingListenerSettings.LoadFrom("TransportSettings") ?? new FabricTransportRemotingListenerSettings();
 			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
 			Name = name;
 			Settings = settings;

--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 					settings = new FabricTransportRemotingListenerSettings();
 				}
 			}
+			
 			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
 			Name = name;
 			Settings = settings;

--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
 		{
+			if (settings == null)
+			{
+				settings = new FabricTransportRemotingListenerSettings();
+			}
+			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
 			Name = name;
 			Settings = settings;
 		}

--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -29,7 +29,13 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
 		{
-			settings = settings ?? FabricTransportRemotingListenerSettings.LoadFrom("TransportSettings") ?? new FabricTransportRemotingListenerSettings();
+			if (settings == null)
+			{
+				if (!FabricTransportRemotingListenerSettings.TryLoadFrom("TransportSettings", out settings))
+				{
+					settings = new FabricTransportRemotingListenerSettings();
+				}
+			}
 			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
 			Name = name;
 			Settings = settings;

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		private static ServiceProxyFactory s_serviceProxyFactory = new(handler =>
 			new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(
-					remotingCallbackMessageHandler: handler)));
+					remotingCallbackMessageHandler: handler,
+					remotingSettings: new FabricTransportRemotingSettings
+					{
+						ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default
+					})));
 
 		/// <summary>
 		/// Binds custom transport settings to the service proxy factory.

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -20,13 +20,14 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	public static class OmexServiceProxyFactory
 	{
 		private static ServiceProxyFactory s_serviceProxyFactory = new(handler =>
-			new OmexServiceRemotingClientFactory(
+		{
+			FabricTransportRemotingSettings remotingSettings = FabricTransportRemotingSettings.LoadFrom("TransportSettings") ?? new FabricTransportRemotingSettings();
+			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
+			return new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(
 					remotingCallbackMessageHandler: handler,
-					remotingSettings: new FabricTransportRemotingSettings
-					{
-						ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default
-					})));
+					remotingSettings: remotingSettings));
+		});
 
 		/// <summary>
 		/// Binds custom transport settings to the service proxy factory.

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 			{
 				remotingSettings = new FabricTransportRemotingSettings();
 			}
+			
 			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
 			return new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 			{
 				remotingSettings = new FabricTransportRemotingSettings();
 			}
-			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default
+			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
 			return new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(
 					remotingCallbackMessageHandler: handler,

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.ServiceFabric.Services.Remoting.Client;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client;
 
 namespace Microsoft.Omex.Extensions.Services.Remoting.Client
@@ -21,8 +22,12 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	{
 		private static ServiceProxyFactory s_serviceProxyFactory = new(handler =>
 		{
-			FabricTransportRemotingSettings remotingSettings = FabricTransportRemotingSettings.LoadFrom("TransportSettings") ?? new FabricTransportRemotingSettings();
-			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
+			FabricTransportRemotingSettings remotingSettings;
+			if (!FabricTransportRemotingSettings.TryLoadFrom("TransportSettings", out remotingSettings))
+			{
+				remotingSettings = new FabricTransportRemotingSettings();
+			}
+			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default
 			return new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(
 					remotingCallbackMessageHandler: handler,

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		/// </summary>
 		public static void WithCustomTransportSettings(FabricTransportRemotingSettings transportSettings)
 		{
+			transportSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
 			s_serviceProxyFactory = new ServiceProxyFactory(handler =>
 				new OmexServiceRemotingClientFactory(
 					new FabricTransportServiceRemotingClientFactory(


### PR DESCRIPTION
We want to discontinue usage of binary formatter based serialization because of security implications. With this change we will switch to data contract based based serialization for remoting exceptions.
More information: https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-exception-serialization