### PR TITLE
Update and register email hash providers

### DIFF
--- a/src/Hosting.Services.Web/Middlewares/UserIdentity/Options/StaticSaltProviderOptions.cs
+++ b/src/Hosting.Services.Web/Middlewares/UserIdentity/Options/StaticSaltProviderOptions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares.UserIdentity.Options
+{
+	/// <summary>
+	/// Options for static salt provider
+	/// </summary>
+	public class StaticSaltProviderOptions
+	{
+		/// <summary>
+		/// Set the hash salt
+		/// </summary>
+		public string SaltValue {  get; set; } = string.Empty;
+	}
+}

--- a/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
+++ b/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares.UserIdentity.Options;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 {
@@ -16,9 +18,9 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 		private readonly IMemoryOwner<byte> m_currentSaltMemory;
 		private readonly byte[] m_saltValue;
 
-		public StaticSaltProvider(string saltValue)
+		public StaticSaltProvider(IOptions<StaticSaltProviderOptions> options)
 		{
-			m_saltValue = Encoding.UTF8.GetBytes(saltValue);
+			m_saltValue = Encoding.UTF8.GetBytes(options.Value.SaltValue);
 			m_currentSaltMemory = MemoryPool<byte>.Shared.Rent(m_saltValue.Length);
 		}
 

--- a/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
+++ b/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
@@ -10,8 +10,7 @@ using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares.UserIdentity.Op
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 {
 	/// <remarks>
-	/// Provider would change salt after 40 hours to make sure that hash could not be traced back to user.
-	/// Salt would be different in each instance so different replicas of the same service would create non-identical hashes for the same user.
+	/// Consumer provides the salt string, this provider then writes the salt to memory
 	/// </remarks>
 	internal class StaticSaltProvider : ISaltProvider
 	{

--- a/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
+++ b/src/Hosting.Services.Web/Middlewares/UserIdentity/SaltProviders/StaticSaltProvider.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Buffers;
-using System.Fabric;
-using System.Security.Cryptography;
-using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 {
@@ -18,13 +15,11 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares
 	{
 		private readonly IMemoryOwner<byte> m_currentSaltMemory;
 		private readonly byte[] m_saltValue;
-		private readonly ILogger<RotatingSaltProvider> m_logger;
 
-		public StaticSaltProvider(byte[] saltValue, ILogger<RotatingSaltProvider> logger)
+		public StaticSaltProvider(string saltValue)
 		{
-			m_currentSaltMemory = MemoryPool<byte>.Shared.Rent(saltValue.Length);
-			m_saltValue = saltValue;
-			m_logger = logger;
+			m_saltValue = Encoding.UTF8.GetBytes(saltValue);
+			m_currentSaltMemory = MemoryPool<byte>.Shared.Rent(m_saltValue.Length);
 		}
 
 		public int MaxBytesInSalt => m_saltValue.Length;

--- a/src/Hosting.Services.Web/ServiceCollectionExtensions.cs
+++ b/src/Hosting.Services.Web/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
+using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares.UserIdentity.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -43,6 +44,18 @@ namespace Microsoft.Extensions.DependencyInjection
 #pragma warning restore CS0618
 
 			return services;
+		}
+
+		/// <summary>
+		/// Register types for Omex middleware with email hash middleware
+		/// </summary>
+		public static IServiceCollection AddOmexMiddlewareWithEmailHash(this IServiceCollection services)
+		{
+			services.AddOptions<StaticSaltProviderOptions>();
+			services.TryAddSingleton<StaticSaltProvider>();
+			services.TryAddEnumerable(ServiceDescriptor.Singleton<IUserIdentityProvider, EmailBasedUserIdentityProvider>());
+			
+			return services.AddOmexMiddleware();
 		}
 	}
 }

--- a/tests/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/StaticSaltProviderTests.cs
+++ b/tests/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/StaticSaltProviderTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
-using System.Linq;
-using System.Text;
+using Microsoft.Extensions.Options;
 using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
+using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares.UserIdentity.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
@@ -15,12 +14,19 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
 		[TestMethod]
 		public void GetSalt_ReturnsConsistentResult()
 		{
-            string saltString1 = "testSaltString1";
-            string saltString2 = "testSaltString2";
+			IOptions<StaticSaltProviderOptions> options1 = Options.Create(new StaticSaltProviderOptions
+			{
+				SaltValue = "testSaltString1"
+			});
 
-			ISaltProvider provider1 = new StaticSaltProvider(saltString1);
-            ISaltProvider provider2 = new StaticSaltProvider(saltString1);
-            ISaltProvider provider3 = new StaticSaltProvider(saltString2);
+			IOptions<StaticSaltProviderOptions> options2 = Options.Create(new StaticSaltProviderOptions
+			{
+				SaltValue = "testSaltString2"
+			});
+
+			ISaltProvider provider1 = new StaticSaltProvider(options1);
+            ISaltProvider provider2 = new StaticSaltProvider(options1);
+            ISaltProvider provider3 = new StaticSaltProvider(options2);
 
 			CollectionAssert.AreEqual(provider1.GetSalt().ToArray(), provider2.GetSalt().ToArray());
             CollectionAssert.AreNotEqual(provider1.GetSalt().ToArray(), provider3.GetSalt().ToArray());

--- a/tests/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/StaticSaltProviderTests.cs
+++ b/tests/Hosting.Services.Web.UnitTests/Middlewares/UserIdentity/StaticSaltProviderTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Omex.Extensions.Hosting.Services.Web.Middlewares;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests
+{
+	[TestClass]
+	public class StaticSaltProviderTests
+	{
+		[TestMethod]
+		public void GetSalt_ReturnsConsistentResult()
+		{
+            string saltString1 = "testSaltString1";
+            string saltString2 = "testSaltString2";
+
+			ISaltProvider provider1 = new StaticSaltProvider(saltString1);
+            ISaltProvider provider2 = new StaticSaltProvider(saltString1);
+            ISaltProvider provider3 = new StaticSaltProvider(saltString2);
+
+			CollectionAssert.AreEqual(provider1.GetSalt().ToArray(), provider2.GetSalt().ToArray());
+            CollectionAssert.AreNotEqual(provider1.GetSalt().ToArray(), provider3.GetSalt().ToArray());
+		}
+	}
+}

--- a/tests/Hosting.Services.Web.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Hosting.Services.Web.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -72,5 +72,36 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.Internal
 
 			Assert.IsInstanceOfType(saltProvider, typeof(EmptySaltProvider));
 		}
+
+		[TestMethod]
+		public void AddStaticSaltProvider_RegistersStaticSaltProvider()
+		{
+			ISaltProvider saltProvider = new HostBuilder()
+				.ConfigureServices((context, collection) =>
+				{
+					collection.AddStaticSaltProvider();
+					collection.AddOmexMiddleware();
+				})
+				.Build().Services
+				.GetRequiredService<ISaltProvider>();
+
+			Assert.IsInstanceOfType(saltProvider, typeof(StaticSaltProvider));
+		}
+
+		[TestMethod]
+		public void AddEmailBasedIdentityProvider_RegistersEmailProvider()
+		{
+			IUserIdentityProvider emailProvider = new HostBuilder()
+				.ConfigureServices((context, collection) =>
+				{
+					collection.AddStaticSaltProvider();
+					collection.AddOmexMiddleware();
+					collection.AddEmailBasedIdentityProvider();
+				})
+				.Build().Services
+				.GetRequiredService<IUserIdentityProvider>();
+
+			Assert.IsInstanceOfType(emailProvider, typeof(EmailBasedUserIdentityProvider));
+		}
 	}
 }


### PR DESCRIPTION
Updated `StaticSaltProvider` to get salt from IOptions;
Update corresponding tests;
Remove unused logger in `StaticSaltProvider`;
Update `ServiceCollectionExtensions` to register correct services.