### PR TITLE
Fix dotnet test parameter syntax

### DIFF
--- a/.github/pipelines/dotnet-tests.yml
+++ b/.github/pipelines/dotnet-tests.yml
@@ -18,7 +18,7 @@ steps:
     inputs:
       command: test
       projects: '**\*.sln'
-      arguments: '-c $(BuildConfiguration) -p:$(BuildParameters) --no-build --no-restore --collect "Code coverage" --filter $(TestFilter)'
+      arguments: '-c $(BuildConfiguration) -p:${{ parameters.BuildParameters }} --no-build --no-restore --collect "Code coverage" --filter ${{ parameters.TestFilter }}'
     timeoutInMinutes: 30
 
   - task: PublishTestResults@2


### PR DESCRIPTION
The syntax used in these parameters was incorrect.
This change corrects the syntax, as per https://learn.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script#use-parameters-in-pipelines.