### PR TITLE
Adding Health Checks `HttpClient` definition

### DIFF
--- a/src/Diagnostics.HealthChecks/HealthCheckHttpClientServiceCollectionExtensions.cs
+++ b/src/Diagnostics.HealthChecks/HealthCheckHttpClientServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// A collection of extension methods to define <seealso cref="HttpClient"/> for Health Checks
+/// in the DI.
+/// </summary>
+public static class HealthCheckHttpClientServiceCollectionExtensions
+{
+	/// <summary>
+	/// Defines a <seealso cref="HttpClient"/> in the DI designed for Health Checks.
+	/// The main difference is that these clients in development will ignore SSL errors.
+	/// This is an acceptable compromise considering that the health checks are executed in the same machine
+	/// as the Service Fabric service itself, and that each client will be specifically used for the
+	/// health checks, as the name parameter in input is mandatory.
+	/// Every other uses of this extension methods apart from health checks should be avoided.
+	/// </summary>
+	/// <param name="services">The services.</param>
+	/// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
+	/// <returns>The <see cref="IHttpClientBuilder"/>.</returns>
+	public static IHttpClientBuilder AddHealthCheckHttpClient(this IServiceCollection services, string name) =>
+		services.AddHttpClient(name)
+			.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+			{
+				ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+			});
+}


### PR DESCRIPTION
## Summary

This PR adds the extension method to define a `HttpClient` instance in the Dependency Injection engine specifically for health checks that must check HTTPS endpoints. This kind of `HttpClient` will remove the added complexity of build and test pipeline to install certificates for localhost in test and release environments.

**Please note** that this kind of `HttpClient`s must be used only for health checks which perform calls to localhost endpoints, and are installed directly in the service in the context of the Service Fabric service.