### PR TITLE
Add SF SDK install template

### DIFF
--- a/.github/pipelines/dotnet-buildandtest.yml
+++ b/.github/pipelines/dotnet-buildandtest.yml
@@ -13,6 +13,7 @@ parameters:
   type: string
   default: FullyQualifiedName!~CloudTests
 steps:
+- template: /.github/pipelines/sf-initialize.yml@self
 - template: /.github/pipelines/dotnet-build.yml@self
   parameters:
     BuildConfiguration: ${{parameters.BuildConfiguration}}

--- a/.github/pipelines/omex-github-official.yml
+++ b/.github/pipelines/omex-github-official.yml
@@ -85,6 +85,7 @@ extends:
               inputs:
                 artifactName: binaries
                 targetPath: bin
+            - template: /.github/pipelines/sf-initialize.yml@self
             - template: /.github/pipelines/dotnet-initialize.yml@self
             - template: /.github/pipelines/dotnet-tests.yml@self
               parameters:

--- a/.github/pipelines/sf-initialize.yml
+++ b/.github/pipelines/sf-initialize.yml
@@ -1,0 +1,16 @@
+# Service Fabric Initialization
+
+parameters:
+  - name: SdkVersion
+    type: string
+    default: "10.0.1816.9590"
+steps:
+  - task: PowerShell@2
+    displayName: Install SF ${{parameters.SdkVersion}}
+    inputs:
+      targetType: 'inline'
+      script: |
+        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force -Scope CurrentUser   
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -OutFile setup.exe -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.${{parameters.SdkVersion}}.exe
+        .\setup.exe  /accepteula /force /quiet


### PR DESCRIPTION
The recent SF10 update introduced a mocking change, which added a runtime dependency on the SF SDK to unit tests.
The change broke both GH and ADO unit test runs.
This change adds an SF SDK install step to the ADO build pipelines to allow integration of the SF 10 update to propagate.