### PR TITLE
[Breaking Change] Make transport settings required

### DIFF
--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
 using System.Fabric;
+using Microsoft.Omex.Extensions.Services.Remoting;
 using Microsoft.Omex.Extensions.Services.Remoting.Runtime;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting;
@@ -33,7 +33,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 		{
 			if (settings == null && !FabricTransportRemotingListenerSettings.TryLoadFrom("TransportSettings", out settings))
 			{
-				throw new InvalidOperationException("Transport security is required for Service Fabric Remoting connections. TransportSettings must be defined in settings.xml.");
+				throw new InsecureRemotingUnsupportedException();
 			}
 
 			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;

--- a/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
+++ b/src/Hosting.Services.Remoting/RemotingListenerBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Fabric;
 using Microsoft.Omex.Extensions.Services.Remoting.Runtime;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
@@ -20,23 +21,21 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting
 		public string Name { get; }
 
 		// done internal for unit tests
-		internal FabricTransportRemotingListenerSettings? Settings { get; }
+		internal FabricTransportRemotingListenerSettings Settings { get; }
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
+		/// <remarks>Transport security settings should be defined in TransportSettings of a service's settings.xml before creating a listener</remarks>
 		protected RemotingListenerBuilder(
 			string name,
 			FabricTransportRemotingListenerSettings? settings = null)
 		{
-			if (settings == null)
+			if (settings == null && !FabricTransportRemotingListenerSettings.TryLoadFrom("TransportSettings", out settings))
 			{
-				if (!FabricTransportRemotingListenerSettings.TryLoadFrom("TransportSettings", out settings))
-				{
-					settings = new FabricTransportRemotingListenerSettings();
-				}
+				throw new InvalidOperationException("Transport security is required for Service Fabric Remoting connections. TransportSettings must be defined in settings.xml.");
 			}
-			
+
 			settings.ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default;
 			Name = name;
 			Settings = settings;

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
 using Microsoft.ServiceFabric.Services.Remoting.Client;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
 using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client;
@@ -24,7 +23,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 		{
 			if (!FabricTransportRemotingSettings.TryLoadFrom("TransportSettings", out FabricTransportRemotingSettings remotingSettings))
 			{
-				throw new InvalidOperationException("Transport security is required for Service Fabric Remoting connections. TransportSettings must be defined in settings.xml.");
+				throw new InsecureRemotingUnsupportedException();
 			}
 
 			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;

--- a/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
+++ b/src/Services.Remoting/Client/OmexServiceProxyFactory.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.ServiceFabric.Services.Remoting.Client;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
-using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client;
 
 namespace Microsoft.Omex.Extensions.Services.Remoting.Client
@@ -13,7 +13,7 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	/// </summary>
 	/// <remarks>
 	/// This wrapper exists to bridge the gap between native service proxy constructs and Service Fabric remoting client creation.
-	/// The default Service Fabric remoting client initialization tries to load transport settings from a 'TransportSettings' section in the service manifest.
+	/// The default behaviour is to load transport settings from the 'TransportSettings' section in the service manifest.
 	/// References:
 	/// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/master/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs#L108
 	/// https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Microsoft.ServiceFabric.FabricTransport/FabricTransport/Common/FabricTransportSettings.cs#L300
@@ -22,12 +22,11 @@ namespace Microsoft.Omex.Extensions.Services.Remoting.Client
 	{
 		private static ServiceProxyFactory s_serviceProxyFactory = new(handler =>
 		{
-			FabricTransportRemotingSettings remotingSettings;
-			if (!FabricTransportRemotingSettings.TryLoadFrom("TransportSettings", out remotingSettings))
+			if (!FabricTransportRemotingSettings.TryLoadFrom("TransportSettings", out FabricTransportRemotingSettings remotingSettings))
 			{
-				remotingSettings = new FabricTransportRemotingSettings();
+				throw new InvalidOperationException("Transport security is required for Service Fabric Remoting connections. TransportSettings must be defined in settings.xml.");
 			}
-			
+
 			remotingSettings.ExceptionDeserializationTechnique = FabricTransportRemotingSettings.ExceptionDeserialization.Default;
 			return new OmexServiceRemotingClientFactory(
 				new FabricTransportServiceRemotingClientFactory(

--- a/src/Services.Remoting/InsecureRemotingUnsupportedException.cs
+++ b/src/Services.Remoting/InsecureRemotingUnsupportedException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.Omex.Extensions.Services.Remoting
+{
+	/// <summary>
+	/// Specific exception type used when an attempt to create an insecure listener or insecure proxy is made.
+	/// </summary>
+	[Serializable]
+	public class InsecureRemotingUnsupportedException : InvalidOperationException
+	{
+		/// <summary>
+		/// Creates an instance of <see cref="InsecureRemotingUnsupportedException"/>.
+		/// </summary>
+		public InsecureRemotingUnsupportedException()
+			: base("Transport security is required for Service Fabric Remoting connections. TransportSettings must be defined in settings.xml.")
+		{
+		}
+	}
+}

--- a/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
+++ b/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
@@ -21,18 +21,13 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests
 			IServiceProvider mockProvider = new Mock<IServiceProvider>().Object;
 			OmexStatefulService omexStatefulService = MockServiceFabricServices.MockOmexStatefulService;
 
-			GenericRemotingListenerBuilder<OmexStatefulService> builder =
-				new(name, mockProvider,
+			Assert.ThrowsException<InvalidOperationException>(() => new GenericRemotingListenerBuilder<OmexStatefulService>(name, mockProvider,
 					(p, s) =>
 					{
 						Assert.AreEqual(omexStatefulService, s);
 						Assert.AreEqual(mockProvider, p);
 						return mockService;
-					});
-
-			Assert.AreEqual(name, builder.Name);
-
-			Assert.ThrowsException<InvalidOperationException>(() => builder.BuildService(omexStatefulService));
+					}));
 		}
 		
 		[TestMethod]

--- a/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
+++ b/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Omex.Extensions.Hosting.Services.UnitTests;
+using Microsoft.Omex.Extensions.Services.Remoting;
 using Microsoft.ServiceFabric.Services.Remoting;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +22,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests
 			IServiceProvider mockProvider = new Mock<IServiceProvider>().Object;
 			OmexStatefulService omexStatefulService = MockServiceFabricServices.MockOmexStatefulService;
 
-			Assert.ThrowsException<InvalidOperationException>(() => new GenericRemotingListenerBuilder<OmexStatefulService>(name, mockProvider,
+			Assert.ThrowsException<InsecureRemotingUnsupportedException>(() => new GenericRemotingListenerBuilder<OmexStatefulService>(name, mockProvider,
 					(p, s) =>
 					{
 						Assert.AreEqual(omexStatefulService, s);

--- a/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
+++ b/tests/Hosting.Services.Remoting.UnitTests/GenericRemotingListenerBuilderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Omex.Extensions.Hosting.Services.UnitTests;
 using Microsoft.ServiceFabric.Services.Remoting;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -13,7 +14,7 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests
 	public class GenericRemotingListenerBuilderTests
 	{
 		[TestMethod]
-		public void GenericRemotingListenerBuilder_PropagatesParameters()
+		public void GenericRemotingListenerBuilder_NoTransportSettigns_ThrowsException()
 		{
 			string name = "TestName";
 			MockService mockService = new();
@@ -28,6 +29,30 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests
 						Assert.AreEqual(mockProvider, p);
 						return mockService;
 					});
+
+			Assert.AreEqual(name, builder.Name);
+
+			Assert.ThrowsException<InvalidOperationException>(() => builder.BuildService(omexStatefulService));
+		}
+		
+		[TestMethod]
+		public void GenericRemotingListenerBuilder_WithTransportSettigns_PropagatesParameters()
+		{
+			string name = "TestName";
+			MockService mockService = new();
+			IServiceProvider mockProvider = new Mock<IServiceProvider>().Object;
+			OmexStatefulService omexStatefulService = MockServiceFabricServices.MockOmexStatefulService;
+			FabricTransportRemotingListenerSettings transportSettings = new();
+
+			GenericRemotingListenerBuilder<OmexStatefulService> builder =
+				new(name, mockProvider,
+					(p, s) =>
+					{
+						Assert.AreEqual(omexStatefulService, s);
+						Assert.AreEqual(mockProvider, p);
+						return mockService;
+					},
+					transportSettings);
 
 			Assert.AreEqual(name, builder.Name);
 

--- a/tests/Hosting.Services.Remoting.UnitTests/MockRemoteListenerBuilder.cs
+++ b/tests/Hosting.Services.Remoting.UnitTests/MockRemoteListenerBuilder.cs
@@ -3,13 +3,14 @@
 
 using System.Fabric;
 using Microsoft.ServiceFabric.Services.Remoting;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 
 namespace Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests
 {
 	internal class MockRemoteListenerBuilder<TService> : RemotingListenerBuilder<TService>
 		where TService : IServiceFabricService<ServiceContext>
 	{
-		public MockRemoteListenerBuilder() : base("TestListener") { }
+		public MockRemoteListenerBuilder() : base("TestListener", new FabricTransportRemotingListenerSettings()) { }
 
 		public override IService BuildService(TService service) => new MockService();
 	}


### PR DESCRIPTION
The current listener and proxy creation logic falls-back on creating insecure listeners and proxies when transport settings are not defined.
This change updates the behaviour to throw when no transport settings are provider or transport settings cannot be loaded from the TransportSettings section of the hosting service's settings.xml file.

Since transport settings can still be defined explicitly, the implementation still allows for insecure connection creation, if the user understands well how to initialise transport settings in an insecure way.
However, most users will use defaults, or follow the Service Fabric documentation which details using LoadFrom to set up secure remoting, so this is not a concern.

FabricTransportSettings.LoadFrom could have been used instead but I think having a descriptive exception message is valuable, so kept TryLoadFrom.

