### PR TITLE
Changed BaseExecutionContext.BuildVersion to numeric

### DIFF
--- a/src/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Runtime.ConstrainedExecution;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
@@ -140,10 +141,16 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 		/// </summary>
 		protected static string GetBuildVersion()
 		{
+			string buildVersion = DefaultEmptyValue;
+
 			Assembly? assembly = Assembly.GetEntryAssembly();
-			return assembly != null
-				? FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion ?? DefaultEmptyValue
-				: DefaultEmptyValue;
+			if (assembly != null)
+			{
+				FileVersionInfo assemblyVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
+				buildVersion = $"{assemblyVersion.ProductMajorPart}.{assemblyVersion.ProductMinorPart}.{assemblyVersion.ProductBuildPart}.{assemblyVersion.ProductPrivatePart}";
+			}
+
+			return buildVersion;
 		}
 
 		/// <summary>

--- a/src/Abstractions/ExecutionContext/BaseExecutionContext.cs
+++ b/src/Abstractions/ExecutionContext/BaseExecutionContext.cs
@@ -147,6 +147,8 @@ namespace Microsoft.Omex.Extensions.Abstractions.ExecutionContext
 			if (assembly != null)
 			{
 				FileVersionInfo assemblyVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
+				// We used assemblyVersion.ProductVersion previously, but in net8 it was changed to include commit hash.
+				// More details here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link
 				buildVersion = $"{assemblyVersion.ProductMajorPart}.{assemblyVersion.ProductMinorPart}.{assemblyVersion.ProductBuildPart}.{assemblyVersion.ProductPrivatePart}";
 			}
 


### PR DESCRIPTION
BuildVersion was returning FileVersionInfo.ProductVersion for the entry assembly, but with .NET 8 assembly informational version includes commit hash for SourceLink. This is a breaking change for logic that relies on well-known x.x.x.x version format.

More details here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link

Rather than disable that behavior completely, I prefer to change BuildVersion logic, this way the native version is still available to dev tools and any other potential use.