### PR TITLE
Remove .NET7 Support

### DIFF
--- a/.github/pipelines/dotnet-initialize.yml
+++ b/.github/pipelines/dotnet-initialize.yml
@@ -11,10 +11,6 @@ steps:
   - task: NuGetAuthenticate@1
     displayName: NuGet Authenticate
   - task: UseDotNet@2
-    displayName: Temporarily install .NET 7 SDK while dual targeting
-    inputs:
-      version: "7.0.404"
-  - task: UseDotNet@2
     displayName: Use .NET SDK from global.json
     inputs:
       useGlobalJson: true

--- a/.github/pipelines/github-semmle.yml
+++ b/.github/pipelines/github-semmle.yml
@@ -36,10 +36,6 @@ extends:
               - checkout: self
                 clean: true
               - task: UseDotNet@2
-                displayName: Temporarily install .NET 7 SDK while dual targeting
-                inputs:
-                  version: "7.0.404"
-              - task: UseDotNet@2
                 displayName: Use .NET SDK from global.json
                 inputs:
                   useGlobalJson: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup Label="Target Platforms" >
     <LatestSupportedDotNetVersion>net8.0</LatestSupportedDotNetVersion>
-    <OldestSupportedDotNetVersion>net7.0</OldestSupportedDotNetVersion>
+    <OldestSupportedDotNetVersion>net8.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
     <NetCoreVersions Condition="'$(LatestSupportedDotNetVersion)' != '$(OldestSupportedDotNetVersion)'">$(LatestSupportedDotNetVersion);$(OldestSupportedDotNetVersion)</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-  <ItemGroup Label="DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)' OR '$(IsNetStandard)'">
+  <ItemGroup Label="DotNet Package Versions. AutoUpdate">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
@@ -24,27 +24,6 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Label="DotNet Package Versions." Condition="'$(TargetFramework)' == '$(OldestSupportedDotNetVersion)'">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="7.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.4" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />


### PR DESCRIPTION
This change updates build targets to stop building for Net7.
It also removes temporary build task additions to install the Net7 SDK.