### PR TITLE
Adding .NET 7 SDK for unit tests

### DIFF
--- a/.github/pipelines/dotnet-initialize.yml
+++ b/.github/pipelines/dotnet-initialize.yml
@@ -11,6 +11,10 @@ steps:
   - task: NuGetAuthenticate@1
     displayName: NuGet Authenticate
   - task: UseDotNet@2
+    displayName: Temporarily install .NET 7 SDK while dual targeting
+    inputs:
+      version: "7.0.405"
+  - task: UseDotNet@2
     displayName: Use .NET SDK from global.json
     inputs:
       useGlobalJson: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
-    <UnitTestTargetFrameworks>net8.0</UnitTestTargetFrameworks>
+    <UnitTestTargetFrameworks>$(NetCoreVersions)</UnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="Project Settings" >
     <Platforms>AnyCPU</Platforms>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,8 +12,7 @@
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
-    <UnitTestTargetFrameworks>$(NetCoreVersions)</UnitTestTargetFrameworks>
-    <UnitTestTargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(NetCoreVersions)</UnitTestTargetFrameworks>
+    <UnitTestTargetFrameworks>$(LatestSupportedDotNetVersion)</UnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="Project Settings" >
     <Platforms>AnyCPU</Platforms>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
-    <UnitTestTargetFrameworks>$(LatestSupportedDotNetVersion)</UnitTestTargetFrameworks>
+    <UnitTestTargetFrameworks>net8.0</UnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="Project Settings" >
     <Platforms>AnyCPU</Platforms>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)'">
-
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />


### PR DESCRIPTION
Tested the removal of NET7 for the unit test projects but this is required for dotnet restore. Re-Added the .NET 7 SDK to the dotnet initialisation.