### PR TITLE
Added Tenant dimension for Activities metric

### DIFF
--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Omex.Extensions.Activities
 
 			TagList tagList = new()
 				{
+					{ "Tenant", $"{m_context.Cluster.ToLowerInvariant()}-{m_hostEnvironment.EnvironmentName.ToLowerInvariant()}-{m_context.DeploymentSlice}" },
 					{ "Name", activity.OperationName },
 					{ "RegionName", m_context.RegionName },
 					{ "ServiceName", m_context.ServiceName },


### PR DESCRIPTION
Adding Tenant dimension for now to cater to existing monitoring. We'll need to define a canonical set of dimensions later and decide whether this class even needs to be open-sourced.