### PR TITLE
Adding NetStandard for Abstractions project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <OldestSupportedDotNetVersion>net7.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
     <NetCoreVersions Condition="'$(LatestSupportedDotNetVersion)' != '$(OldestSupportedDotNetVersion)'">$(LatestSupportedDotNetVersion);$(OldestSupportedDotNetVersion)</NetCoreVersions>
-    <LibraryTargetFrameworks>$(NetCoreVersions)</LibraryTargetFrameworks>
-    <ExecutableTargetFrameworks>$(NetCoreVersions)</ExecutableTargetFrameworks>
+    <NetStandardVersions>netstandard2.0</NetStandardVersions>
+    <LibraryTargetFrameworks>$(NetCoreVersions);$(NetStandardVersions)</LibraryTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="UnitTest Targets">
     <UnitTestTargetFrameworks>$(NetCoreVersions)</UnitTestTargetFrameworks>
@@ -24,6 +24,10 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Label="Condition Variables" >
+    <IsNetCore>$(NetCoreVersions.Contains('$(TargetFramework)'))</IsNetCore>
+    <IsNetStandard>$(NetStandardVersions.Contains('$(TargetFramework)'))</IsNetStandard>
   </PropertyGroup>
   <PropertyGroup Label="Signing" >
     <SignAssembly>true</SignAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Label="Condition Variables" >
-    <IsNetCore>$(NetCoreVersions.Contains('$(TargetFramework)'))</IsNetCore>
     <IsNetStandard>$(NetStandardVersions.Contains('$(TargetFramework)'))</IsNetStandard>
   </PropertyGroup>
   <PropertyGroup Label="Signing" >

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-  <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)'">
+  <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)' OR '$(IsNetStandard)'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />

--- a/Omex.sln
+++ b/Omex.sln
@@ -20,7 +20,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		NuGet.Config = NuGet.Config

--- a/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
+  <ItemGroup Condition="!$(IsNetCore)">
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
 </Project>

--- a/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
-  <ItemGroup Condition="!$(IsNetCore)">
+  <ItemGroup Condition="$(IsNetStandard)">
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 </Project>

--- a/src/Abstractions/Validation.cs
+++ b/src/Abstractions/Validation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Omex.Extensions.Abstractions
 		{
 			if (!string.IsNullOrWhiteSpace(value))
 			{
-				return value;
+				return value!; // `!` required because in netstandard2.0 IsNullOrWhiteSpace does not have proper attributes
 			}
 
 			_ = value ?? throw new ArgumentNullException(name);

--- a/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
+++ b/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Activities</Title>

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">

--- a/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
+++ b/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">

--- a/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
+++ b/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">

--- a/src/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
+++ b/src/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Hosting</Title>

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Logging</Title>

--- a/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
+++ b/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
+++ b/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">

--- a/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
+++ b/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Properties">


### PR DESCRIPTION
This is still used down the chain in one location. Keeping the support isolated to this one project and will hopefully be able to drop it later. Removed the Library target from other locations to keep the updates maintainable.