### PR TITLE
Disable PathMap for debug to fix symbols mapping

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -75,7 +75,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SourceRootLocation>$(MSBuildThisFileDirectory)</SourceRootLocation>
     <!-- 
-      Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive to keep automatic log tags independand of the build location.
+      Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive to keep automatic log tags independent of the build location.
       Doing this prevents debugger from finding symbols, so setting is disabled for debug builds.
     -->
     <PathMap Condition="'$(Configuration)' != 'Debug'">$(MSBuildThisFileDirectory)=/</PathMap>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,10 @@
     <!-- Optional: Include the PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SourceRootLocation>$(MSBuildThisFileDirectory)</SourceRootLocation>
-    <!-- Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive -->
-    <PathMap>$(MSBuildThisFileDirectory)=/</PathMap>
+    <!-- 
+      Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive to keep automatic log tags independand of the build location.
+      Doing this prevents debugger from finding symbols, so setting is disabled for debug builds.
+    -->
+    <PathMap Condition="'$(Configuration)' != 'Debug'">$(MSBuildThisFileDirectory)=/</PathMap>
   </PropertyGroup>
 </Project>

--- a/tests/Abstractions.UnitTests/TagTests.cs
+++ b/tests/Abstractions.UnitTests/TagTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using Microsoft.Extensions.Logging;
@@ -22,8 +22,17 @@ namespace Microsoft.Omex.Extensions.Abstractions.UnitTests
 
 
 			string relativePath = "/tests/Abstractions.UnitTests/" + nameof(TagTests) + ".cs"; //This value should be change in case of changing file path or name
-			Assert.AreEqual(tag1.Name, relativePath, "tag1 Name should point to current file");
-			Assert.AreEqual(tag2.Name, relativePath, "tag2 Name should point to current file");
+			AssertTagNames(relativePath, tag1.Name, "tag1 Name should point to current file");
+			AssertTagNames(relativePath, tag2.Name, "tag2 Name should point to current file");
+		}
+
+		private static void AssertTagNames(string expectedTag, string? actualTag, string message)
+		{
+#if DEBUG
+			StringAssert.EndsWith(actualTag?.Replace('\\','/'), expectedTag, message);
+#else
+			Assert.AreEqual(expectedTag, actualTag, message);
+#endif
 		}
 
 		[DataTestMethod]


### PR DESCRIPTION
Enabling it for debug prevent debugger from loading symbols