### PR TITLE
Drop Net7 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup Label="Target Platforms" >
     <LatestSupportedDotNetVersion>net8.0</LatestSupportedDotNetVersion>
-    <OldestSupportedDotNetVersion>net7.0</OldestSupportedDotNetVersion>
+    <OldestSupportedDotNetVersion>net8.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
     <NetCoreVersions Condition="'$(LatestSupportedDotNetVersion)' != '$(OldestSupportedDotNetVersion)'">$(LatestSupportedDotNetVersion);$(OldestSupportedDotNetVersion)</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>


### PR DESCRIPTION
This was forgotten about when .Net7 support was being dropped elsewhere.
This is blocking https://github.com/microsoft/Omex/pull/670.