### PR TITLE
Support both .NET 8 and .NET 9

### DIFF
--- a/.github/pipelines/dotnet-initialize.yml
+++ b/.github/pipelines/dotnet-initialize.yml
@@ -11,9 +11,9 @@ steps:
   - task: NuGetAuthenticate@1
     displayName: NuGet Authenticate
   - task: UseDotNet@2
-    displayName: Temporarily install .NET 7 SDK while dual targeting
+    displayName: Temporarily install .NET 8 SDK while dual targeting
     inputs:
-      version: "7.0.405"
+      version: "8.0.404"
   - task: UseDotNet@2
     displayName: Use .NET SDK from global.json
     inputs:

--- a/.github/pipelines/github-forward.yml
+++ b/.github/pipelines/github-forward.yml
@@ -87,7 +87,7 @@ extends:
             Title: GitHub Forward Integration - $(GITHUBCOMMIT)
             Description: GitHub forward integration Pull Request for commit '$(GITHUBCOMMIT)'
             SkipIfNoChangesFound: false
-            WorkItemId: "8430180"
+            WorkItemId: "9421495"
             AutoCompleteUserId: 75d3c7a0-2045-6bf0-b50e-3ab2cf9ae644
             Pat: $(OfficeOcCodeAccessCorpNet)
             MergeStrategy: noFastForward

--- a/.github/pipelines/github-packageupdate.yml
+++ b/.github/pipelines/github-packageupdate.yml
@@ -53,6 +53,6 @@ extends:
             TargetBranchName: main
             Title: Automatic NuGet package update
             Description: update of NuGet packages
-            WorkItemId: "9127473"
+            WorkItemId: "9421495"
             Pat: $(omexgithubbotinternalpat)
             MergeStrategy: "0"

--- a/.github/pipelines/github-semmle.yml
+++ b/.github/pipelines/github-semmle.yml
@@ -38,6 +38,10 @@ extends:
               - checkout: self
                 clean: true
               - task: UseDotNet@2
+                displayName: Temporarily install .NET 8 SDK while dual targeting
+                inputs:
+                  version: "8.0.404"
+              - task: UseDotNet@2
                 displayName: Use .NET SDK from global.json
                 inputs:
                   useGlobalJson: true

--- a/.github/pipelines/sf-initialize.yml
+++ b/.github/pipelines/sf-initialize.yml
@@ -3,14 +3,14 @@
 parameters:
   - name: SdkVersion
     type: string
-    default: "10.1.2175.9590"
+    default: "10.1.2448.9590"
 steps:
   - task: PowerShell@2
     displayName: Install SF ${{parameters.SdkVersion}}
     inputs:
       targetType: 'inline'
       script: |
-        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force -Scope CurrentUser   
+        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force -Scope CurrentUser
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -OutFile setup.exe -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.${{parameters.SdkVersion}}.exe
         .\setup.exe  /accepteula /force /quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,19 @@ jobs:
       IsReleaseBuild: ${{ matrix.configuration == 'Release' && github.event_name == 'release' && !github.event.release.prerelease && github.ref == 'refs/heads/master' }}
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install .NET 8 SDK
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
-    # Install SF SDK
-    - name: Install SF
+    - name: Install .NET 9 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+    - name: Install SF SDK
       shell: powershell
-      run: | 
+      run: |
         Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force -Scope CurrentUser
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -OutFile setup.exe -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.10.1.2448.9590.exe

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - name: Install .NET 8 SDK
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
+    - name: Install .NET 9 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Target Platforms" >
-    <LatestSupportedDotNetVersion>net8.0</LatestSupportedDotNetVersion>
+    <LatestSupportedDotNetVersion>net9.0</LatestSupportedDotNetVersion>
     <OldestSupportedDotNetVersion>net8.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
     <NetCoreVersions Condition="'$(LatestSupportedDotNetVersion)' != '$(OldestSupportedDotNetVersion)'">$(LatestSupportedDotNetVersion);$(OldestSupportedDotNetVersion)</NetCoreVersions>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <RepoRoot Condition="'$(RepoRoot)' == ''">$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('global.json', '$(MSBuildProjectDirectory)'))))</RepoRoot>
   </PropertyGroup>
-
-  <PropertyGroup Label="Target Platforms" >
+  <PropertyGroup Label="Target Platforms">
     <LatestSupportedDotNetVersion>net9.0</LatestSupportedDotNetVersion>
     <OldestSupportedDotNetVersion>net8.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
@@ -14,7 +13,7 @@
   <PropertyGroup Label="UnitTest Targets">
     <UnitTestTargetFrameworks>$(NetCoreVersions)</UnitTestTargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Label="Project Settings" >
+  <PropertyGroup Label="Project Settings">
     <Platforms>AnyCPU</Platforms>
     <TargetPlatform>AnyCPU</TargetPlatform>
     <ErrorReport>prompt</ErrorReport>
@@ -25,16 +24,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <PropertyGroup Label="Condition Variables" >
+  <PropertyGroup Label="Condition Variables">
     <IsNetStandard>$(NetStandardVersions.Contains('$(TargetFramework)'))</IsNetStandard>
   </PropertyGroup>
-  <PropertyGroup Label="Signing" >
+  <PropertyGroup Label="Signing">
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\OmexOpenSource.snk</AssemblyOriginatorKeyFile>
     <StrongNameSuffix>, PublicKey=00240000048000009400000006020000002400005253413100040000010001004d77aff3ec12650e8979fb873e4b409556a1a650482e6d4dfcf9fea3c87dc334dc2f08ab4820ad3555b949a172553484f5f8fecd302db2907a5d8e3c33d394276c05e18865c5776e0c1f04bba8c4d3e4b12bc44b70e70dc076cc69611b04368d7eff2e83f5b016db366f9d572dad24f09adc6ae732802958048b69727561d1bd</StrongNameSuffix>
   </PropertyGroup>
-  <PropertyGroup Label="Build Output" >
+  <PropertyGroup Label="Build Output">
     <BaseOutputPath>$(MSBuildThisFileDirectory)\bin\$(MSBuildProjectName)</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)\nuget</PackageOutputPath>
@@ -58,7 +57,7 @@
     <Description>$(MSBuildProjectName)</Description>
     <Tags>Omex</Tags>
   </PropertyGroup>
-  <PropertyGroup Label="Debug Information" >
+  <PropertyGroup Label="Debug Information">
     <EnableSourceControlManagerQueries Condition="'$(CommitSha)' != ''">false</EnableSourceControlManagerQueries>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/Omex</RepositoryUrl>
@@ -74,7 +73,7 @@
     <!-- Optional: Include the PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SourceRootLocation>$(MSBuildThisFileDirectory)</SourceRootLocation>
-    <!-- 
+    <!--
       Maps paths injected by CallerFilePath attribute to be related and independent from repository location on hard drive to keep automatic log tags independent of the build location.
       Doing this prevents debugger from finding symbols, so setting is disabled for debug builds.
     -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,14 +30,14 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.11" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" PreserveMajor="true" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,25 +26,25 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Label="Previous DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(OldestSupportedDotNetVersion)' And '$(OldestSupportedDotNetVersion)' != '$(LatestSupportedDotNetVersion)'">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.20" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="7.0.20" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PreserveMajor="true" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" PreserveMajor="true" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.4" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PreserveMajor="true" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" PreserveMajor="true" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" PreserveMajor="true" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,25 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)' OR '$(IsNetStandard)'">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Label="Previous DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(OldestSupportedDotNetVersion)' And '$(OldestSupportedDotNetVersion)' != '$(LatestSupportedDotNetVersion)'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PreserveMajor="true" />
@@ -47,15 +47,15 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" PreserveMajor="true" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Net.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.Net.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Label="ServiceFabric packages for Omex Extensions">
     <PackageVersion Include="Microsoft.ServiceFabric" Version="10.1.2448" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.100",
     "rollForward": "latestMajor"
   }
 }

--- a/tests/Activities.UnitTests/Internal/ActivityListenerInitializerServiceTests.cs
+++ b/tests/Activities.UnitTests/Internal/ActivityListenerInitializerServiceTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 			// check that Activity from Diagnostic listener also captured
 			using (DiagnosticListener listener = new(nameof(ActivityListeners_ControlsActivityCreation)))
 			{
-				Activity activity = new("DiagnosticsListenerActivity");
+				using Activity activity = new("DiagnosticsListenerActivity");
 
 				listener.StartActivity(activity, null);
 				mockStartObserver.Verify(s => s.OnStart(activity, null), Times.Once);

--- a/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
+++ b/tests/Activities.UnitTests/Internal/ActivityMetricsSenderTests.cs
@@ -179,14 +179,13 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests.Internal
 			Listener listener = new();
 
 			string? parentName = hasParentName ? nameof(parentName) : null;
-			if (hasParentActivity)
-			{
-				Activity parent = new(parentName!);
-				parent.Start();
-			}
+			using Activity? parent = hasParentActivity ? new(parentName!) : null;
+			parent?.Start();
 
-			Activity activity = new(nameof(activity));
+			using Activity activity = new(nameof(activity));
 			activity.Start().Stop();
+
+			parent?.Stop();
 
 			sender.SendActivityMetric(activity);
 

--- a/tests/Activities.UnitTests/Internal/ActivityObserverTests.cs
+++ b/tests/Activities.UnitTests/Internal/ActivityObserverTests.cs
@@ -22,7 +22,7 @@ namespace Hosting.Services.UnitTests
 		[TestMethod]
 		public void OnStop_CallsLogActivityStop()
 		{
-			Activity activity = new(nameof(OnStop_CallsLogActivityStop));
+			using Activity activity = new(nameof(OnStop_CallsLogActivityStop));
 			(ActivityObserver observer, _, Mock<IActivitiesEventSender> senderMock) = CreateObserver();
 
 			observer.OnStop(activity, null);
@@ -53,7 +53,7 @@ namespace Hosting.Services.UnitTests
 		[DataRow(false, ActivityResult.ExpectedError)]
 		public void OnStop_LogsStop(bool isSuccesful, ActivityResult? result)
 		{
-			Activity activity = new Activity(nameof(OnStop_LogsStop))
+			using Activity activity = new Activity(nameof(OnStop_LogsStop))
 				.Start()
 				.SetBaggage("SomeValue", "BaggageValue")
 				.SetTag("SomeTag", "TagValue");

--- a/tests/Activities.UnitTests/ServiceCollectionTests.cs
+++ b/tests/Activities.UnitTests/ServiceCollectionTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Diagnostics;
 using System;
-using Microsoft.Omex.Extensions.Abstractions.Activities.Processing;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Omex.Extensions.Abstractions.Activities.Processing;
 using Microsoft.Omex.Extensions.Testing.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Omex.Extensions.Activities.UnitTests
 {
@@ -45,7 +45,7 @@ namespace Microsoft.Omex.Extensions.Activities.UnitTests
 		{
 			Task task = CreateHost().RunAsync();
 
-			Activity? activity = new ActivitySource("Source")
+			using Activity? activity = new ActivitySource("Source")
 				.StartActivity(nameof(AddOmexActivitySource_HostedServicesRegistered));
 
 			NullableAssert.IsNotNull(activity, "Activity creation enabled after host started");

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Diagnostics.HealthChecks.UnitTests/CertificatesValidityHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/CertificatesValidityHealthCheckTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		[TestMethod]
 		public async Task CheckHealthAsync_ShouldReturnUnhealthy_WhenCertificateDoesNotHavePrivateKey()
 		{
-#if NET9_0
+#if NET9_0_OR_GREATER
 			X509Certificate2 certWithoutPrivateKey = X509CertificateLoader.LoadCertificate(CreateCert(m_certSubjectName).Export(X509ContentType.Cert));
 #else
 			X509Certificate2 certWithoutPrivateKey = new(CreateCert(m_certSubjectName).Export(X509ContentType.Cert));

--- a/tests/Diagnostics.HealthChecks.UnitTests/CertificatesValidityHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/CertificatesValidityHealthCheckTests.cs
@@ -122,7 +122,12 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests
 		[TestMethod]
 		public async Task CheckHealthAsync_ShouldReturnUnhealthy_WhenCertificateDoesNotHavePrivateKey()
 		{
+#if NET9_0
+			X509Certificate2 certWithoutPrivateKey = X509CertificateLoader.LoadCertificate(CreateCert(m_certSubjectName).Export(X509ContentType.Cert));
+#else
 			X509Certificate2 certWithoutPrivateKey = new(CreateCert(m_certSubjectName).Export(X509ContentType.Cert));
+#endif
+
 			m_certificateReaderMock.Setup(m => m.GetCertificateByCommonName(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<StoreName>()))
 				.Returns(certWithoutPrivateKey);
 

--- a/tests/Hosting.Services.Web.UnitTests/HostBuilderExtensionsTests.cs
+++ b/tests/Hosting.Services.Web.UnitTests/HostBuilderExtensionsTests.cs
@@ -34,8 +34,10 @@ namespace Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.Internal
 		[TestMethod]
 		public async Task BuildStatelessWebService_RegisterListeners()
 		{
-			(string name, int port) httpListener1 = ("httpListener", 20080);
-			(string name, int port) httpListener2 = ("httpsListener", 20443);
+			// Use random ports from private range.
+			Random random = new Random();
+			(string name, int port) httpListener1 = ("httpListener", random.Next(49152, 65535));
+			(string name, int port) httpListener2 = ("httpsListener", random.Next(49152, 65535));
 
 			SfConfigurationProviderHelper.SetPublishAddress();
 			SfConfigurationProviderHelper.SetPortVariable(httpListener1.name, httpListener1.port);

--- a/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
+++ b/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Added net9.0 support to published packages.
- Enabled dual SDK installation in pipelines.
- Fixed flaky tests which were failing in VS Test Explorer and in "dotnet test".