### PR TITLE
Pinned major version for framework packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,8 +64,7 @@
     <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="7.1.2448" />
     <PackageVersion Include="ServiceFabric.Mocks" Version="7.2.8" />
   </ItemGroup>
-  <ItemGroup Label="Moq">
-    <!-- Pinning moq due to [SponsorLink privacy concerns](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/moq-incident-and-remediation) -->
+  <ItemGroup Label="Moq pinned to 4.18.4 until SponsorLink is fully removed and new versions are deemed trustworty">
     <PackageVersion Include="Moq" Version="4.18.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,6 @@
   </ItemGroup>
   <ItemGroup Label="Moq">
     <!-- Pinning moq due to [SponsorLink privacy concerns](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/moq-incident-and-remediation) -->
-    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,23 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)' OR '$(IsNetStandard)'">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" PreserveMajor="true" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" PreserveMajor="true" />
   </ItemGroup>
   <ItemGroup Label="Previous DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(OldestSupportedDotNetVersion)' And '$(OldestSupportedDotNetVersion)' != '$(LatestSupportedDotNetVersion)'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PreserveMajor="true" />
@@ -41,8 +39,6 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" PreserveMajor="true" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" PreserveMajor="true" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PreserveMajor="true" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" PreserveMajor="true" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" PreserveMajor="true" />
   </ItemGroup>
@@ -52,6 +48,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Net.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
@@ -66,7 +64,8 @@
     <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="7.1.2448" />
     <PackageVersion Include="ServiceFabric.Mocks" Version="7.2.8" />
   </ItemGroup>
-  <ItemGroup Label="Moq pinned to 4.18.4 until SponsorLink is fully removed and new versions are deemed trustworty">
-    <PackageVersion Include="Moq" Version="4.18.4" />
+  <ItemGroup Label="Moq">
+    <!-- Pinning moq due to [SponsorLink privacy concerns](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/moq-incident-and-remediation) -->
+    <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Pinning the packages which comprise a part of .NET. This way we have to manually update the major version once when moving to .NET vNext, but we don't have to downgrade the packages in every package update PR between vNext release and our upgrade.