### PR TITLE
Add health check dimension in the default constructor for tag definon

### DIFF
--- a/src/Activities/CustomActivityDimensions/CustomTagObjectsDimensions.cs
+++ b/src/Activities/CustomActivityDimensions/CustomTagObjectsDimensions.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Omex.Extensions.Activities
 	public class CustomTagObjectsDimensions : ICustomTagObjectsDimensions
 	{
 		/// <summary>
-		/// Default constructor which has <seealso cref="ActivityTagKeys.Result"/>, <seealso cref="ActivityTagKeys.SubType"/>, <seealso cref="ActivityTagKeys.Metadata"/>
+		/// Default constructor which has <seealso cref="ActivityTagKeys.Result"/>, <seealso cref="ActivityTagKeys.SubType"/>, <seealso cref="ActivityTagKeys.Metadata"/>, <seealso cref="ActivityTagKeys.HealthCheckResult"/>
 		/// </summary>
-		public CustomTagObjectsDimensions() => CustomDimensions = new HashSet<string>() { ActivityTagKeys.Result, ActivityTagKeys.SubType, ActivityTagKeys.Metadata };
+		public CustomTagObjectsDimensions() => CustomDimensions = new HashSet<string>() { ActivityTagKeys.Result, ActivityTagKeys.SubType, ActivityTagKeys.Metadata, ActivityTagKeys.HealthCheckResult };
 
 		/// <summary>
 		/// Override the default constructor to specify custom dimension set.


### PR DESCRIPTION
Add a health check result tag key to the default constructor for tag definitions in the `CustomTagObjectsDimensions` class.