### PR TITLE
Restored net8.0 target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Target Platforms">
     <LatestSupportedDotNetVersion>net9.0</LatestSupportedDotNetVersion>
-    <OldestSupportedDotNetVersion>net9.0</OldestSupportedDotNetVersion>
+    <OldestSupportedDotNetVersion>net8.0</OldestSupportedDotNetVersion>
     <NetCoreVersions>$(LatestSupportedDotNetVersion)</NetCoreVersions>
     <NetCoreVersions Condition="'$(LatestSupportedDotNetVersion)' != '$(OldestSupportedDotNetVersion)'">$(LatestSupportedDotNetVersion);$(OldestSupportedDotNetVersion)</NetCoreVersions>
     <NetStandardVersions>netstandard2.0</NetStandardVersions>


### PR DESCRIPTION
Was too hasty removing net8.0 target, that can only be done once all dependent projects have been upgraded to net9.0.