### PR TITLE
Switching Platform to AnyCPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+AnyCPU/
 x64/
 x86/
 bld/

--- a/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
+++ b/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore</Title>

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Diagnostics.HealthChecks</Title>

--- a/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
+++ b/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Hosting.Services.Remoting</Title>

--- a/src/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
+++ b/src/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Hosting.Services.Web</Title>

--- a/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
+++ b/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Hosting.Services</Title>

--- a/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
+++ b/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Properties">

--- a/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
+++ b/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersions)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Label="NuGet Properties">
     <Title>Microsoft.Omex.Extensions.Services.Remoting</Title>

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Diagnostics.HealthChecks.AspNetCore\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj" />

--- a/tests/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Diagnostics.HealthChecks\Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj" />

--- a/tests/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
+++ b/tests/Hosting.Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Remoting.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hosting.Services.Remoting\Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj" />

--- a/tests/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
+++ b/tests/Hosting.Services.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />

--- a/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
+++ b/tests/Hosting.Services.Web.UnitTests/Microsoft.Omex.Extensions.Hosting.Services.Web.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hosting.Services.Web\Microsoft.Omex.Extensions.Hosting.Services.Web.csproj" />

--- a/tests/ServiceFabricGuest.Abstractions.UnitTests/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests.csproj
+++ b/tests/ServiceFabricGuest.Abstractions.UnitTests/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hosting\Microsoft.Omex.Extensions.Hosting.csproj" />

--- a/tests/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
+++ b/tests/Services.Remoting.UnitTests/Microsoft.Omex.Extensions.Services.Remoting.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(TargetPlatform)</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Actors" />


### PR DESCRIPTION
Making platform agnostic to platform type to allow usage of native AMR64 in the future.