### PR TITLE
Add `dotnet-sdk` to `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: 
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
This change allows Dependabot to keep the .NET SDK up-to-date in `global.json`. See [Using Dependabot to Manage .NET SDK Updates][1].

[1]: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/