### PR TITLE
Adding ExpectedStatus[] Option to composable Healthchecks

### DIFF
--- a/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheck.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheck.cs
@@ -35,6 +35,7 @@ internal class EndpointLivenessHealthCheck : IHealthCheck
 			CreateHttpRequestMessage,
 			activitySource,
 			httpClientFactory,
+			expectedStatus: parameters.ExpectedStatus,
 			httpClientName: parameters.HttpClientLogicalName)
 				.AsObservableHealthCheck(activitySource, logger, parameters: parameters);
 	}

--- a/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/EndpointLivenessHealthCheckParameters.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 
 namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore;
@@ -19,8 +20,13 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 	public string EndpointName { get; }
 
 	/// <summary>
+	/// The expected HTTP status code that will be returned by the endpoint.
+	/// </summary>
+	public HttpStatusCode[] ExpectedStatus { get; } = [HttpStatusCode.OK];
+
+	/// <summary>
 	/// The URI scheme that will be used to query the endpoint.
-	/// The default value will be equa to HTTP.
+	/// The default value will be equal to HTTP.
 	/// </summary>
 	public string UriScheme { get; } = Uri.UriSchemeHttp;
 
@@ -49,6 +55,7 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 	/// <param name="endpointRelativeUrl">
 	/// The endpoint relative url at which the Service Fabric health check will be reachable.
 	/// </param>
+	/// <param name="expectedStatus">Collection of allowed HttpStatusCode Responses for a check to succeed, default is HttpStatusCode.OK</param>
 	/// <param name="host">The host used to perform the health check HTTP call to the service.</param>
 	/// <param name="uriScheme">
 	/// The URI scheme to use to call the endpoint.
@@ -60,6 +67,7 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 		string endpointName,
 		string httpClientLogicalName,
 		string endpointRelativeUrl,
+		HttpStatusCode[]? expectedStatus = null,
 		string host = "localhost",
 		string? uriScheme = null,
 		params KeyValuePair<string, object>[] reportData)
@@ -68,6 +76,7 @@ public class EndpointLivenessHealthCheckParameters : HealthCheckParameters
 		EndpointName = endpointName;
 		HttpClientLogicalName = httpClientLogicalName;
 		EndpointRelativeUri = endpointRelativeUrl;
+		ExpectedStatus = expectedStatus ?? [HttpStatusCode.OK];
 		Host = host;
 		UriScheme = uriScheme ?? Uri.UriSchemeHttp;
 	}

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -28,6 +28,7 @@ public static class HealthCheckComposablesExtensions
 		Func<HttpRequestMessage> requestBuilder,
 		ActivitySource activitySource,
 		IHttpClientFactory httpClientFactory,
+		
 		string? httpClientName = "") =>
 			Composables.HealthCheckComposablesExtensions.CreateHttpHealthCheck(
 				requestBuilder,
@@ -45,6 +46,7 @@ public static class HealthCheckComposablesExtensions
 	/// <param name="failureStatus">
 	/// The health check failure status that will be reported if the health check fails.
 	/// </param>
+	/// <param name="expectedStatus">Collection of allowed HttpStatusCode Responses for a check to succeed, default is HttpsStatusCode.OK</param>
 	/// <param name="parameters">
 	/// The health check parameters. Notice that these parameters will have to be an instance of the <see cref="EndpointLivenessHealthCheckParameters"/> class.
 	/// </param>
@@ -53,11 +55,13 @@ public static class HealthCheckComposablesExtensions
 		this IHealthChecksBuilder healthChecksBuilder,
 		string name,
 		HealthStatus? failureStatus,
+		HttpStatusCode[] expectedStatus = [],
 		EndpointLivenessHealthCheckParameters parameters) =>
 		healthChecksBuilder
 			.AddTypeActivatedCheck<EndpointLivenessHealthCheck>(
 				name,
 				failureStatus,
+				expectedStatus
 				parameters);
 
 	/// <summary>
@@ -80,6 +84,7 @@ public static class HealthCheckComposablesExtensions
 	/// to pass either value.
 	/// If not specified, the default value used will be <seealso cref="Uri.UriSchemeHttp"/>.
 	/// </param>
+	/// <param name="expectedStatus">Collection of allowed HttpStatusCode Responses for a check to succeed, default is HttpsStatusCode.OK</param>
 	/// <param name="reportData">The report data parameters.</param>
 	/// <returns>The Health Check builder.</returns>
 	public static IHealthChecksBuilder AddEndpointHttpHealthCheck(
@@ -91,6 +96,7 @@ public static class HealthCheckComposablesExtensions
 		HealthStatus failureStatus = HealthStatus.Unhealthy,
 		string host = "localhost",
 		string? uriScheme = null,
+		HttpStatusCode[] expectedStatus = [],
 		params KeyValuePair<string, object>[] reportData)
 	{
 		EndpointLivenessHealthCheckParameters parameters = new(

--- a/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks.AspNetCore/HealthCheckComposablesExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -22,17 +23,18 @@ public static class HealthCheckComposablesExtensions
 	/// <param name="requestBuilder">The request builder.</param>
 	/// <param name="activitySource">The activity source.</param>
 	/// <param name="httpClientFactory">The http client factory.</param>
+	/// <param name="expectedStatus">Collection of allowed HttpStatusCode Responses for a check to succeed, default is HttpStatusCode.OK</param>
 	/// <param name="httpClientName">The HTTP Client name, if a client with that name was registered in particular.</param>
 	/// <returns>The HTTP endpoint checker health check.</returns>
 	public static IHealthCheck CreateLivenessHttpHealthCheck(
 		Func<HttpRequestMessage> requestBuilder,
 		ActivitySource activitySource,
 		IHttpClientFactory httpClientFactory,
-		
+		HttpStatusCode[]? expectedStatus = null,
 		string? httpClientName = "") =>
 			Composables.HealthCheckComposablesExtensions.CreateHttpHealthCheck(
 				requestBuilder,
-				async (context, response, _) => await Composables.HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response),
+				async (context, response, _) => await Composables.HealthCheckComposablesExtensions.CheckResponseStatusCodeAsync(context, response, expectedStatus),
 				activitySource,
 				httpClientFactory,
 				httpClientName: httpClientName,
@@ -46,7 +48,6 @@ public static class HealthCheckComposablesExtensions
 	/// <param name="failureStatus">
 	/// The health check failure status that will be reported if the health check fails.
 	/// </param>
-	/// <param name="expectedStatus">Collection of allowed HttpStatusCode Responses for a check to succeed, default is HttpsStatusCode.OK</param>
 	/// <param name="parameters">
 	/// The health check parameters. Notice that these parameters will have to be an instance of the <see cref="EndpointLivenessHealthCheckParameters"/> class.
 	/// </param>
@@ -55,13 +56,11 @@ public static class HealthCheckComposablesExtensions
 		this IHealthChecksBuilder healthChecksBuilder,
 		string name,
 		HealthStatus? failureStatus,
-		HttpStatusCode[] expectedStatus = [],
 		EndpointLivenessHealthCheckParameters parameters) =>
 		healthChecksBuilder
 			.AddTypeActivatedCheck<EndpointLivenessHealthCheck>(
 				name,
 				failureStatus,
-				expectedStatus
 				parameters);
 
 	/// <summary>
@@ -96,13 +95,14 @@ public static class HealthCheckComposablesExtensions
 		HealthStatus failureStatus = HealthStatus.Unhealthy,
 		string host = "localhost",
 		string? uriScheme = null,
-		HttpStatusCode[] expectedStatus = [],
+		HttpStatusCode[]? expectedStatus = null,
 		params KeyValuePair<string, object>[] reportData)
 	{
 		EndpointLivenessHealthCheckParameters parameters = new(
 			endpointName,
 			httpClientLogicalName,
 			relativePath,
+			expectedStatus,
 			host,
 			uriScheme: uriScheme,
 			reportData: reportData

--- a/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
+++ b/src/Diagnostics.HealthChecks/Composables/HealthCheckComposablesExtensions.cs
@@ -96,7 +96,7 @@ public static class HealthCheckComposablesExtensions
 	{
 		if (allowedStatusCodes == null || allowedStatusCodes.Length == 0)
 		{
-			allowedStatusCodes = new[] { HttpStatusCode.OK };
+			allowedStatusCodes = [HttpStatusCode.OK];
 		}
 
 		if (allowedStatusCodes.Contains(response.StatusCode))

--- a/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthzEndpointHealthCheck.cs
+++ b/tests/Diagnostics.HealthChecks.AspNetCore.UnitTests/HealthzEndpointHealthCheck.cs
@@ -59,41 +59,43 @@ public class HealthzEndpointHealthCheckTests
 		Assert.AreEqual(expectedHealthStatus, healthCheckResult.Status);
 	}
 
-	[TestMethod]
-	[DataRow(HttpStatusCode.OK, HealthStatus.Healthy)]
-	[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Unhealthy)]
-	[DataRow(HttpStatusCode.NotFound, HealthStatus.Unhealthy)]
-	[DataRow(HttpStatusCode.Unauthorized, HealthStatus.Unhealthy)]
-	[DataRow(HttpStatusCode.Forbidden, HealthStatus.Unhealthy)]
-	public async Task HealthzEndpointHttpHealthCheck_ReturnsExpectedStatus2(HttpStatusCode returnedStatusCode, HealthStatus expectedHealthStatus)
-	{
-		EndpointLivenessHealthCheckParameters healthCheckParameters = new(
-			nameof(EndpointLivenessHealthCheck),
-			$"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
-			"healthz",
-			[returnedStatusCode]);
+    [TestMethod]
+    [DataRow(new[] { HttpStatusCode.OK }, HttpStatusCode.OK, HealthStatus.Healthy)]
+    [DataRow(new[] { HttpStatusCode.Unauthorized }, HttpStatusCode.Unauthorized, HealthStatus.Healthy)]
+    [DataRow(new[] { HttpStatusCode.NotFound }, HttpStatusCode.OK, HealthStatus.Unhealthy)]
+    [DataRow(new[] { HttpStatusCode.NotFound }, HttpStatusCode.NotFound, HealthStatus.Healthy)]
+    [DataRow(new[] { HttpStatusCode.NotFound, HttpStatusCode.OK }, HttpStatusCode.NotFound, HealthStatus.Healthy)]
+    [DataRow(new[] { HttpStatusCode.NotFound, HttpStatusCode.OK }, HttpStatusCode.Unauthorized, HealthStatus.Unhealthy)]
+	public async Task HealthzEndpointHttpHealthCheckWithExpectedStatusCodes_ReturnsExpectedStatus(HttpStatusCode[] expectedStatusCode, HttpStatusCode returnedStatusCode, HealthStatus expectedHealthStatus)
+    {
+        EndpointLivenessHealthCheckParameters healthCheckParameters = new(
+            nameof(EndpointLivenessHealthCheck),
+            $"{nameof(EndpointLivenessHealthCheck)}_HttpClient",
+            "healthz",
+            expectedStatusCode);
 
-		HealthCheckTestHelpers.SetLocalServiceInfo();
-		Mock<IHttpClientFactory> clientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
-			HealthCheckTestHelpers.GetHttpResponseMessageMock(returnedStatusCode, message: string.Empty));
+        HealthCheckTestHelpers.SetLocalServiceInfo();
+        Mock<IHttpClientFactory> clientFactory = HealthCheckTestHelpers.GetHttpClientFactoryMock(
+            HealthCheckTestHelpers.GetHttpResponseMessageMock(returnedStatusCode, message: string.Empty));
 
-		ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
+        ActivitySource activitySourceMock = new(nameof(EndpointLivenessHealthCheck));
 
-		IHealthCheck healthCheck = new EndpointLivenessHealthCheck(
-			clientFactory.Object,
-			activitySourceMock,
-			GetLogger<EndpointLivenessHealthCheck>(),
-			healthCheckParameters);
+        EndpointLivenessHealthCheck healthCheck = new(
+            clientFactory.Object,
+            activitySourceMock,
+            GetLogger<EndpointLivenessHealthCheck>(),
+            healthCheckParameters);
 
-		CancellationTokenSource source = new();
+        CancellationTokenSource source = new();
 
-		HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
-			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
-			source.Token);
+        HealthCheckResult healthCheckResult = await healthCheck.CheckHealthAsync(
+            HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
+            source.Token);
 
-		Assert.AreEqual(expectedHealthStatus, healthCheckResult.Status);
-	}
+        Assert.AreEqual(expectedHealthStatus, healthCheckResult.Status);
+    }
 
+ 
 	[TestMethod]
 	[DataRow(HttpStatusCode.OK, HealthStatus.Healthy)]
 	[DataRow(HttpStatusCode.InternalServerError, HealthStatus.Unhealthy)]

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
@@ -48,7 +48,6 @@ public class HttpEndpointHealthCheckTests
 			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
 			source.Token);
 
-		Assert.IsNotNull(result);
 		Assert.AreEqual(expectedHealthStatus, result.Status);
 	}
 
@@ -81,7 +80,6 @@ public class HttpEndpointHealthCheckTests
 			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
 			source.Token);
 
-		Assert.IsNotNull(result);
 		Assert.AreEqual(expectedHealthStatus, result.Status);
 	}
 
@@ -109,7 +107,6 @@ public class HttpEndpointHealthCheckTests
 			HealthCheckTestHelpers.GetHealthCheckContext(healthCheck),
 			source.Token);
 
-		Assert.IsNotNull(result);
 		Assert.AreEqual(expectedHealthStatus, result.Status);
 	}
 }

--- a/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
+++ b/tests/Diagnostics.HealthChecks.UnitTests/Composables/HttpEndpointHealthCheckTests.cs
@@ -7,8 +7,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Omex.Extensions.Diagnostics.HealthChecks.Composables;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -19,8 +17,6 @@ namespace Microsoft.Omex.Extensions.Diagnostics.HealthChecks.UnitTests.Composabl
 public class HttpEndpointHealthCheckTests
 {
 	private static readonly ActivitySource s_activitySource = new(nameof(ObservableHealthCheckTests));
-
-	private static readonly ILogger s_logger = NullLogger.Instance;
 
 	[TestMethod]
 	[DataRow(HttpStatusCode.OK, HealthStatus.Healthy)]


### PR DESCRIPTION
We currently only support status == OK, this would allow other valid checks to be run such as UnAuthorised.