### PR TITLE
Making Telemetry strings available for re-use

### DIFF
--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -23,6 +23,16 @@ namespace Microsoft.Omex.Extensions.Activities
 		private readonly HashSet<string> m_customTagObjectsDimension;
 		private readonly bool m_isSetParentNameAsDimensionEnabled;
 
+		/// <summary>
+		/// The name of the activities histogram metric.
+		/// </summary>
+		public const string ActivitiesHistogramName = "Activities";
+
+		/// <summary>
+		/// The name of the HealtchCheck activities histogram metric.
+		/// </summary>
+		public const string HealthCheckActivitiesHistogramName = "HealthCheckActivities";
+
 		public ActivityMetricsSender(
 			IExecutionContext executionContext,
 			IHostEnvironment hostEnvironment,
@@ -33,8 +43,8 @@ namespace Microsoft.Omex.Extensions.Activities
 			m_context = executionContext;
 			m_hostEnvironment = hostEnvironment;
 			m_meter = new Meter("Microsoft.Omex.Activities", "1.0.0");
-			m_activityHistogram = m_meter.CreateHistogram<long>("Activities");
-			m_healthCheckActivityHistogram = m_meter.CreateHistogram<long>("HealthCheckActivities");
+			m_activityHistogram = m_meter.CreateHistogram<long>(ActivitiesHistogramName);
+			m_healthCheckActivityHistogram = m_meter.CreateHistogram<long>(HealthCheckActivitiesHistogramName);
 			m_customBaggageDimension = customBaggageDimensions.CustomDimensions;
 			m_customTagObjectsDimension = customTagObjectsDimensions.CustomDimensions;
 			m_isSetParentNameAsDimensionEnabled = activityOptions.Value.SetParentNameAsDimensionEnabled;

--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Omex.Extensions.Activities
 		/// </summary>
 		public const string HealthCheckActivitiesHistogramName = "HealthCheckActivities";
 
+		/// <summary>
+		/// The name of the Meter that is used to record activity metrics.
+		/// </summary>
+		public const string MeterName = "Microsoft.Omex.Activities";
+
 		public ActivityMetricsSender(
 			IExecutionContext executionContext,
 			IHostEnvironment hostEnvironment,
@@ -42,7 +47,7 @@ namespace Microsoft.Omex.Extensions.Activities
 		{
 			m_context = executionContext;
 			m_hostEnvironment = hostEnvironment;
-			m_meter = new Meter("Microsoft.Omex.Activities", "1.0.0");
+			m_meter = new Meter(MeterName, "1.0.0");
 			m_activityHistogram = m_meter.CreateHistogram<long>(ActivitiesHistogramName);
 			m_healthCheckActivityHistogram = m_meter.CreateHistogram<long>(HealthCheckActivitiesHistogramName);
 			m_customBaggageDimension = customBaggageDimensions.CustomDimensions;


### PR DESCRIPTION
Currently these are just being used as strings in the code where it's needed, making them available outside of this class so that logging can be configured correctly in other classes.