### PR TITLE
Correcting <PackageProjectUrl>

### DIFF
--- a/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
+++ b/src/Abstractions/Microsoft.Omex.Extensions.Abstractions.csproj
@@ -7,7 +7,7 @@
     <Summary>Microsoft Omex Extensions Abstractions</Summary>
     <Description>This library contains abstraction interfaces used in the Omex Extensions.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Abstractions</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Abstractions</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
+++ b/src/Activities/Microsoft.Omex.Extensions.Activities.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Activities</Summary>
     <Description>This library facilitates emitting of activities.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Activities</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Activities</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Activities</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
+++ b/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Diagnostics HealthChecks.AspNetCore</Summary>
     <Description>This library adds support to Omex Health Checks to ASP.NET Core controllers.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Diagnostics.HealthChecks</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Diagnostics.HealthChecks.AspNetCore</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;HealthChecks;AspNetCore</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
+++ b/src/Diagnostics.HealthChecks.AspNetCore/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Diagnostics HealthChecks.AspNetCore</Summary>
     <Description>This library adds support to Omex Health Checks to ASP.NET Core controllers.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Diagnostics.HealthChecks</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Diagnostics.HealthChecks</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;HealthChecks;AspNetCore</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/Diagnostics.HealthChecks/Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Diagnostics HealthChecks</Summary>
     <Description>This library faciliates creating and running health checks in Service Fabric.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Diagnostics.HealthChecks</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Diagnostics.HealthChecks</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;HealthChecks</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
+++ b/src/Hosting.Services.Remoting/Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Hosting Services Remoting</Summary>
     <Description>This library contains functionality to configure the Service Fabric remoting listeners.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Hosting.Services.Remoting</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Hosting.Services.Remoting</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Hosting;Services</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
+++ b/src/Hosting.Services.Web/Microsoft.Omex.Extensions.Hosting.Services.Web.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Hosting Services Web</Summary>
     <Description>This library contains functionality to configure the Service Fabric Kestrel listeners, and additional middleware to enable tracing.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Hosting.Services.Web</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Hosting.Services.Web</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Hosting;Services;Web</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
+++ b/src/Hosting.Services/Microsoft.Omex.Extensions.Hosting.Services.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Hosting Services</Summary>
     <Description>This library contains functionality to configure the Service Fabric host listeners.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Hosting.Services</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Hosting.Services</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Hosting;Services</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
+++ b/src/Hosting/Microsoft.Omex.Extensions.Hosting.csproj
@@ -7,7 +7,7 @@
     <Summary>Microsoft Omex Extensions Hosting</Summary>
     <Description>This library contains functionality to configure the Service Fabric host.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Hosting</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Hosting</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Hosting</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
+++ b/src/Logging/Microsoft.Omex.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
     <Summary>Microsoft Omex Extensions Logging</Summary>
     <Description>This library contains functionality to configure and initialize the logging infrastructure.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Logging</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Logging</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Logging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
+++ b/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
@@ -9,7 +9,7 @@
     <Summary>Microsoft Omex Extensions ServiceFabricGuest Abstractions</Summary>
     <Description>This library contains abstractions for Service Fabric Guest Executables</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Abstractions</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/ServiceFabricGuest.Abstractions</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;ServiceFabricGuest;Abstractions</PackageTags>
   </PropertyGroup>
 

--- a/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
+++ b/src/ServiceFabricGuest.Abstractions/Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj
@@ -9,7 +9,7 @@
     <Summary>Microsoft Omex Extensions ServiceFabricGuest Abstractions</Summary>
     <Description>This library contains abstractions for Service Fabric Guest Executables</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Abstractions</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Abstractions</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;ServiceFabricGuest;Abstractions</PackageTags>
   </PropertyGroup>
 

--- a/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
+++ b/src/Services.Remoting/Microsoft.Omex.Extensions.Services.Remoting.csproj
@@ -8,7 +8,7 @@
     <Summary>Microsoft Omex Extensions Services Remoting</Summary>
     <Description>This library contains wrappers and extensions for Service Fabric Remoting clients.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Services.Remoting</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Services.Remoting</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Services;Remoting</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
+++ b/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
@@ -9,7 +9,7 @@
     <Summary>Microsoft Omex Extensions Testing Helpers</Summary>
     <Description>This library contains helpers for testing the Omex Extensions.</Description>
     <ReleaseNotes>Initial release.</ReleaseNotes>
-    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Extensions/Testing.Helpers</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Omex/tree/main/src/Testing.Helpers</PackageProjectUrl>
     <PackageTags>Microsoft;Omex;Extensions;Testing</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the `PackageProjectUrl` property in multiple `.csproj` files to point to the correct project paths in the repository. The changes ensure that the NuGet package metadata accurately reflects the new or correct source code locations after a restructuring or move of the source folders.

**Project metadata corrections:**

* Updated `PackageProjectUrl` in the following project files to remove the outdated `/Extensions/` subfolder and point directly to the correct source directories:
  - `Microsoft.Omex.Extensions.Abstractions.csproj` (`src/Abstractions`)
  - `Microsoft.Omex.Extensions.Activities.csproj` (`src/Activities`)
  - `Microsoft.Omex.Extensions.Diagnostics.HealthChecks.AspNetCore.csproj` (`src/Diagnostics.HealthChecks.AspNetCore`)
  - `Microsoft.Omex.Extensions.Diagnostics.HealthChecks.csproj` (`src/Diagnostics.HealthChecks`)
  - `Microsoft.Omex.Extensions.Hosting.Services.Remoting.csproj` (`src/Hosting.Services.Remoting`)
  - `Microsoft.Omex.Extensions.Hosting.Services.Web.csproj` (`src/Hosting.Services.Web`)
  - `Microsoft.Omex.Extensions.Hosting.Services.csproj` (`src/Hosting.Services`)
  - `Microsoft.Omex.Extensions.Hosting.csproj` (`src/Hosting`)
  - `Microsoft.Omex.Extensions.Logging.csproj` (`src/Logging`)
  - `Microsoft.Omex.Extensions.ServiceFabricGuest.Abstractions.csproj` (`src/ServiceFabricGuest.Abstractions`)
  - `Microsoft.Omex.Extensions.Services.Remoting.csproj` (`src/Services.Remoting`)
  - `Microsoft.Omex.Extensions.Testing.Helpers.csproj` (`src/Testing.Helpers`)