### PR TITLE
XS✔ ◾ Onboarding PR Metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: PR Metrics
-      uses: microsoft/PR-Metrics@latest
+      uses: microsoft/PR-Metrics@v1.7.5
       env:
         PR_METRICS_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: PR Metrics
-      uses: microsoft/PR-Metrics@v1
+      uses: microsoft/PR-Metrics@latest
       env:
         PR_METRICS_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,22 @@ on:
       - published
 
 jobs:
+  pr-metrics:
+    name: PR Metrics
+    runs-on: windows-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: PR Metrics
+      uses: microsoft/PR-Metrics@v1
+      env:
+        PR_METRICS_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This pull request adds a new GitHub Actions job to the CI workflow for collecting pull request metrics. The new job uses Microsoft's PR Metrics action to gather and report PR statistics.

**CI/CD Workflow Enhancements:**

* Added a `pr-metrics` job to `.github/workflows/build.yml` that runs on Windows, checks out the repository, and uses the `microsoft/PR-Metrics@v1` action to collect pull request metrics. This job is configured with the necessary permissions and uses the repository's GitHub token for authentication.