### PR TITLE
XS✔ ◾ Upgrade package versions in Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,41 +5,41 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Latest DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(LatestSupportedDotNetVersion)' OR '$(IsNetStandard)'">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.8"/>
-    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.1.0"/>
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>
+    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.3.0"/>
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8"/>
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.9"/>
     <PackageVersion Include="System.Linq.Async" Version="6.0.3"/>
-    <PackageVersion Include="System.Text.Json" Version="9.0.8"/>
+    <PackageVersion Include="System.Text.Json" Version="9.0.9"/>
   </ItemGroup>
   <ItemGroup Label="Previous DotNet Package Versions. AutoUpdate" Condition="'$(TargetFramework)' == '$(OldestSupportedDotNetVersion)' And '$(OldestSupportedDotNetVersion)' != '$(LatestSupportedDotNetVersion)'">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" PreserveMajor="true"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.19" PreserveMajor="true"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.20" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" PreserveMajor="true"/>
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.19" PreserveMajor="true"/>
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.20" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" PreserveMajor="true"/>
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" PreserveMajor="true"/>
@@ -49,8 +49,8 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.6" PreserveMajor="true"/>
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.10.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.10.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Net.Test.Sdk" Version="17.14.1" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.304",
+    "version": "9.0.305",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This pull request updates several NuGet package versions in the `Directory.Packages.props` file to ensure the project uses the latest dependencies. The changes primarily focus on bumping versions for various Microsoft.Extensions libraries, feature management, diagnostics, and test packages.

**Dependency version updates:**

* Updated multiple `Microsoft.Extensions.*` packages (such as `DependencyInjection`, `Logging`, `Options`, etc.) from version 9.0.8 to 9.0.9 for the latest .NET target, and incremented some 8.x packages for older targets (e.g., `Microsoft.Extensions.Diagnostics.HealthChecks` and `Microsoft.Extensions.ObjectPool` from 8.0.19 to 8.0.20).
* Bumped `Microsoft.FeatureManagement` from 4.1.0 to 4.3.0 for the latest .NET target.
* Upgraded `System.Diagnostics.DiagnosticSource` and `System.Text.Json` from 9.0.8 to 9.0.9 for the latest .NET target.
* Updated test dependencies `MSTest.TestAdapter` and `MSTest.TestFramework` from 3.10.3 to 3.10.4.Updated package versions for various dependencies.
