### PR TITLE
XS✔ ◾ Replace separate MSTest packages with unified MSTest meta-package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.16" PreserveMajor="true" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
-    <PackageVersion Include="MSTest" Version="4.2.1" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="4.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,12 +43,10 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.16" PreserveMajor="true" />
   </ItemGroup>
   <ItemGroup Label="Package Versions. AutoUpdate">
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageVersion Include="MSTest" Version="4.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="10.0.300" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
+++ b/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
+++ b/src/Testing.Helpers/Microsoft.Omex.Extensions.Testing.Helpers.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,9 +5,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="MSTest.TestAdapter" PrivateAssets="All" />
-    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest" />
+    <PackageReference Include="MSTest" PrivateAssets="All" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace MSTest.TestAdapter, MSTest.TestFramework, and Microsoft.NET.Test.Sdk with the single MSTest 4.2.3 meta-package which transitively includes all three.