### PR TITLE
fix: truncate baggage/tag values to prevent metrics cardinality explosion

### DIFF
--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -23,11 +23,8 @@ namespace Microsoft.Omex.Extensions.Activities
 		private readonly HashSet<string> m_customTagObjectsDimension;
 		private readonly bool m_isSetParentNameAsDimensionEnabled;
 
-		/// <summary>
-		/// Maximum length for metric tag values to prevent
-		/// cardinality explosion via externally controlled
-		/// baggage or tag values.
-		/// </summary>
+		// Caps metric tag value length to reduce cardinality risk
+		// from externally controlled baggage or tag values
 		private const int MaxMetricTagValueLength = 256;
 
 		public ActivityMetricsSender(
@@ -75,11 +72,7 @@ namespace Microsoft.Omex.Extensions.Activities
 				string? baggageItem = activity.GetBaggageItem(dimension);
 				if (!string.IsNullOrWhiteSpace(baggageItem))
 				{
-					// Truncate to prevent metrics cardinality explosion
-					// via externally controlled W3C baggage header values
-					tagList.Add(dimension, baggageItem.Length > MaxMetricTagValueLength
-						? baggageItem[..MaxMetricTagValueLength]
-						: baggageItem);
+					tagList.Add(dimension, TruncateSafe(baggageItem, MaxMetricTagValueLength));
 				}
 			}
 
@@ -88,12 +81,16 @@ namespace Microsoft.Omex.Extensions.Activities
 				object? tagItem = activity.GetTagItem(dimension);
 				if (tagItem != null)
 				{
-					// Truncate string representation to prevent
-					// cardinality explosion via high-cardinality tag values
-					string tagValue = tagItem.ToString() ?? string.Empty;
-					tagList.Add(dimension, tagValue.Length > MaxMetricTagValueLength
-						? tagValue[..MaxMetricTagValueLength]
-						: tagValue);
+					// Only truncate string values — preserve original
+					// type for numeric/bool to avoid breaking exporters
+					if (tagItem is string stringValue)
+					{
+						tagList.Add(dimension, TruncateSafe(stringValue, MaxMetricTagValueLength));
+					}
+					else
+					{
+						tagList.Add(dimension, tagItem);
+					}
 				}
 			}
 
@@ -107,6 +104,19 @@ namespace Microsoft.Omex.Extensions.Activities
 			}
 
 			histogram.Record(durationMs, tagList);
+		}
+
+		// Truncates string to maxLength while avoiding
+		// splitting UTF-16 surrogate pairs
+		private static string TruncateSafe(string value, int maxLength)
+		{
+			if (value.Length <= maxLength)
+				return value;
+
+			if (char.IsHighSurrogate(value[maxLength - 1]))
+				return value[..(maxLength - 1)];
+
+			return value[..maxLength];
 		}
 
 		public void Dispose() => m_meter.Dispose();

--- a/src/Activities/Internal/ActivityMetricsSender.cs
+++ b/src/Activities/Internal/ActivityMetricsSender.cs
@@ -23,6 +23,13 @@ namespace Microsoft.Omex.Extensions.Activities
 		private readonly HashSet<string> m_customTagObjectsDimension;
 		private readonly bool m_isSetParentNameAsDimensionEnabled;
 
+		/// <summary>
+		/// Maximum length for metric tag values to prevent
+		/// cardinality explosion via externally controlled
+		/// baggage or tag values.
+		/// </summary>
+		private const int MaxMetricTagValueLength = 256;
+
 		public ActivityMetricsSender(
 			IExecutionContext executionContext,
 			IHostEnvironment hostEnvironment,
@@ -68,7 +75,11 @@ namespace Microsoft.Omex.Extensions.Activities
 				string? baggageItem = activity.GetBaggageItem(dimension);
 				if (!string.IsNullOrWhiteSpace(baggageItem))
 				{
-					tagList.Add(dimension, baggageItem);
+					// Truncate to prevent metrics cardinality explosion
+					// via externally controlled W3C baggage header values
+					tagList.Add(dimension, baggageItem.Length > MaxMetricTagValueLength
+						? baggageItem[..MaxMetricTagValueLength]
+						: baggageItem);
 				}
 			}
 
@@ -77,7 +88,12 @@ namespace Microsoft.Omex.Extensions.Activities
 				object? tagItem = activity.GetTagItem(dimension);
 				if (tagItem != null)
 				{
-					tagList.Add(dimension, tagItem);
+					// Truncate string representation to prevent
+					// cardinality explosion via high-cardinality tag values
+					string tagValue = tagItem.ToString() ?? string.Empty;
+					tagList.Add(dimension, tagValue.Length > MaxMetricTagValueLength
+						? tagValue[..MaxMetricTagValueLength]
+						: tagValue);
 				}
 			}
 


### PR DESCRIPTION
## Problem

`SendActivityMetric()` writes W3C baggage header values 
directly into metrics tag dimensions without any length 
validation:

```csharp
// Before fix — no length check
tagList.Add(dimension, baggageItem);
```

In distributed systems, baggage propagates across service
boundaries via HTTP headers. If baggage values are externally
controlled (e.g. user-supplied correlation IDs), each unique
value creates a new permanent time series in the metrics backend.

This can cause:
- Metrics cardinality explosion
- Metrics backend memory exhaustion
- Loss of observability (alerts stop firing)
- Unexpected Azure Monitor cost spikes

Same class of issue as GHSA-rcjv-mgp8-qvmr in 
OpenTelemetry-Go, which was assigned a CVE.

## Fix

Added `MaxMetricTagValueLength = 256` constant and truncate
both baggage values and tag object values before writing
to metrics dimensions.

```csharp
// After fix — length capped
tagList.Add(dimension, baggageItem.Length > MaxMetricTagValueLength
    ? baggageItem[..MaxMetricTagValueLength]
    : baggageItem);
```

## Impact of Fix

- Prevents unbounded time series growth
- Preserves legitimate low-cardinality usage
- No breaking change to existing behavior

## References
- GHSA-rcjv-mgp8-qvmr (same class, OpenTelemetry-Go)
- CWE-400: Uncontrolled Resource Consumption
- https://opentelemetry.io/docs/languages/dotnet/metrics/best-practices/