### PR TITLE
XS⚠️ ◾ Clarify parameter documentation and set default value for enableCorrelationHeaderBackwardCompatibility

### DIFF
--- a/src/Hosting.Services.Web/ApplicationBuilderExtensions.cs
+++ b/src/Hosting.Services.Web/ApplicationBuilderExtensions.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNetCore.Builder
 		/// </summary>
 		/// <param name="builder">Application builder</param>
 		/// <param name="environment">Environment information</param>
-		/// <param name="enableCorrelationHeaderBackwardCompatibility">Set it to true if the service needs to accept a request with old style correlation</param>
+		/// <param name="enableCorrelationHeaderBackwardCompatibility">(Optional) Set it to true if the service needs to accept a request with old style correlation</param>
 		public static IApplicationBuilder UseOmexMiddlewares(
 			this IApplicationBuilder builder,
 			IHostEnvironment environment,
-			bool enableCorrelationHeaderBackwardCompatibility)
+			bool enableCorrelationHeaderBackwardCompatibility = false)
 		{
 			builder
 				.UseOmexExceptionHandler(environment)

--- a/src/Hosting.Services.Web/ApplicationBuilderExtensions.cs
+++ b/src/Hosting.Services.Web/ApplicationBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Builder
 		/// </summary>
 		/// <param name="builder">Application builder</param>
 		/// <param name="environment">Environment information</param>
-		/// <param name="enableCorrelationHeaderBackwardCompatibility">(Optional) Set it to true if the service needs to accept a request with old style correlation</param>
+		/// <param name="enableCorrelationHeaderBackwardCompatibility">An optional <see cref="bool"/> indicating whether to enable legacy correlation header/query support via <see cref="UseObsoleteCorrelationHeadersMiddleware"/>. Defaults to <c>false</c>.</param>
 		public static IApplicationBuilder UseOmexMiddlewares(
 			this IApplicationBuilder builder,
 			IHostEnvironment environment,


### PR DESCRIPTION
Updated XML documentation to clarify parameter usage and set a default value for enableCorrelationHeaderBackwardCompatibility.

This path is obsolete if set to true and this allows the setting to be omitted entirely for services which don't use it.