### PR TITLE
Adopt GitHub App Authentication

### DIFF
--- a/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
+++ b/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
@@ -1,0 +1,207 @@
+# Mints a short-lived Microsoft Omex installation token using the App private
+# key stored in Azure Key Vault. Shared by GitHub Actions and Azure Pipelines.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$apiUrl = 'https://api.github.com'
+$outputVariable = 'GitHubAppToken'
+
+$clientId = 'Iv23lid6KuWM6H8RIU1i'
+$owner = 'microsoft'
+$repositoryName = 'Omex'
+$vaultName = 'OmexOpenSourceKV'
+$secretName = 'microsoft-omex-github-app'
+
+$permissionsJson = $env:GITHUB_APP_PERMISSIONS
+if ([string]::IsNullOrWhiteSpace($permissionsJson))
+{
+    throw "The 'GITHUB_APP_PERMISSIONS' environment variable is not set."
+}
+
+function ConvertTo-Base64Url
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [byte[]] $Bytes
+    )
+
+    return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Get-GitHubAppPrivateKey
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $VaultName,
+        [Parameter(Mandatory = $true)]
+        [string] $SecretName
+    )
+
+    $secretJson = az keyvault secret show --vault-name $VaultName --name $SecretName --query value --output json | Out-String
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($secretJson))
+    {
+        throw "Could not read secret '$SecretName' from Azure Key Vault '$VaultName'. Ensure the caller is signed in with an identity holding the 'Key Vault Secrets User' role."
+    }
+
+    $secret = $secretJson | ConvertFrom-Json
+    if ([string]::IsNullOrWhiteSpace($secret))
+    {
+        throw "Azure Key Vault secret '$SecretName' is empty."
+    }
+
+    if ($secret.TrimStart().StartsWith('-----BEGIN'))
+    {
+        return $secret
+    }
+
+    try
+    {
+        $decoded = [System.Text.Encoding]::UTF8.GetString(
+            [System.Convert]::FromBase64String(($secret -replace '\s', '')))
+    }
+    catch
+    {
+        throw "Azure Key Vault secret '$SecretName' must contain the GitHub App RSA private key as PEM text or Base64 encoded PEM. A GitHub App OAuth client secret cannot mint an installation token."
+    }
+
+    if (-not $decoded.TrimStart().StartsWith('-----BEGIN'))
+    {
+        throw "Azure Key Vault secret '$SecretName' must contain the GitHub App RSA private key as PEM text or Base64 encoded PEM. A GitHub App OAuth client secret cannot mint an installation token."
+    }
+
+    return $decoded
+}
+
+function Get-JsonWebToken
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $ClientId,
+        [Parameter(Mandatory = $true)]
+        [string] $PrivateKey
+    )
+
+    $issuedAt = [System.DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $header = [ordered] @{
+        alg = 'RS256'
+        typ = 'JWT'
+    }
+    $payload = [ordered] @{
+        exp = $issuedAt + 540
+        iat = $issuedAt - 60
+        iss = $ClientId
+    }
+
+    $headerEncoded = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress)))
+    $payloadEncoded = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+    $signingInput = "$headerEncoded.$payloadEncoded"
+
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try
+    {
+        try
+        {
+            $rsa.ImportFromPem($PrivateKey)
+        }
+        catch
+        {
+            throw "Azure Key Vault secret '$secretName' does not contain a valid RSA private key: $($_.Exception.Message)"
+        }
+
+        $signature = $rsa.SignData(
+            [System.Text.Encoding]::ASCII.GetBytes($signingInput),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    }
+    finally
+    {
+        $rsa.Dispose()
+    }
+
+    return "$signingInput.$(ConvertTo-Base64Url -Bytes $signature)"
+}
+
+function Invoke-GitHubApi
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $Uri,
+        [Parameter(Mandatory = $true)]
+        [string] $Jwt,
+        [Parameter(Mandatory = $true)]
+        [string] $Method,
+        [Parameter(Mandatory = $false)]
+        [object] $Body
+    )
+
+    $parameters = @{
+        Uri       = $Uri
+        Method    = $Method
+        UserAgent = 'Omex'
+        Headers   = @{
+            Accept                 = 'application/vnd.github+json'
+            Authorization          = "Bearer $Jwt"
+            'X-GitHub-Api-Version' = '2022-11-28'
+        }
+    }
+    if ($null -ne $Body)
+    {
+        $parameters.Body = $Body | ConvertTo-Json -Compress -Depth 10
+        $parameters.ContentType = 'application/json'
+    }
+
+    try
+    {
+        return Invoke-RestMethod @parameters
+    }
+    catch
+    {
+        $detail = $_.ErrorDetails.Message
+        if ([string]::IsNullOrWhiteSpace($detail))
+        {
+            $detail = $_.Exception.Message
+        }
+
+        throw "GitHub API request to '$Uri' failed: $detail"
+    }
+}
+
+$privateKey = Get-GitHubAppPrivateKey -VaultName $vaultName -SecretName $secretName
+$jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
+
+$installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$owner/$repositoryName/installation" -Jwt $jwt -Method 'Get'
+if ($null -eq $installation.id)
+{
+    throw "Could not determine the App installation for '$owner/$repositoryName'."
+}
+
+$body = @{
+    repositories = @($repositoryName)
+    permissions  = ($permissionsJson | ConvertFrom-Json)
+}
+$accessToken = Invoke-GitHubApi -Uri "$apiUrl/app/installations/$($installation.id)/access_tokens" -Jwt $jwt -Method 'Post' -Body $body
+if ([string]::IsNullOrWhiteSpace($accessToken.token))
+{
+    throw 'The GitHub App installation token could not be minted.'
+}
+
+if ($env:GITHUB_ACTIONS -eq 'true')
+{
+    Write-Output -InputObject "::add-mask::$($accessToken.token)"
+    "token=$($accessToken.token)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+}
+elseif (-not [string]::IsNullOrWhiteSpace($env:TF_BUILD))
+{
+    Write-Output -InputObject "##vso[task.setvariable variable=$outputVariable;issecret=true]$($accessToken.token)"
+}
+else
+{
+    throw 'Unable to determine the CI host: neither GITHUB_ACTIONS nor TF_BUILD is set.'
+}
+
+Write-Output -InputObject "Minted an installation token for '$owner/$repositoryName' (installation $($installation.id))."

--- a/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
+++ b/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
@@ -82,7 +82,9 @@ function Get-JsonWebToken
         [Parameter(Mandatory = $true)]
         [string] $ClientId,
         [Parameter(Mandatory = $true)]
-        [string] $PrivateKey
+        [string] $PrivateKey,
+        [Parameter(Mandatory = $true)]
+        [string] $SecretName
     )
 
     $issuedAt = [System.DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
@@ -109,7 +111,7 @@ function Get-JsonWebToken
         }
         catch
         {
-            throw "Azure Key Vault secret '$secretName' does not contain a valid RSA private key: $($_.Exception.Message)"
+            throw "Azure Key Vault secret '$SecretName' does not contain a valid RSA private key: $($_.Exception.Message)"
         }
 
         $signature = $rsa.SignData(
@@ -145,6 +147,7 @@ function Invoke-GitHubApi
         UserAgent = 'Omex'
         Headers   = @{
             Accept                 = 'application/vnd.github+json'
+            # Review tooling may redact this value in diffs. Runtime uses the supplied JWT.
             Authorization          = "Bearer $Jwt"
             'X-GitHub-Api-Version' = '2022-11-28'
         }
@@ -172,7 +175,7 @@ function Invoke-GitHubApi
 }
 
 $privateKey = Get-GitHubAppPrivateKey -VaultName $vaultName -SecretName $secretName
-$jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
+$jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey -SecretName $secretName
 
 $installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$owner/$repositoryName/installation" -Jwt $jwt -Method 'Get'
 if ($null -eq $installation.id)
@@ -193,7 +196,7 @@ if ([string]::IsNullOrWhiteSpace($accessToken.token))
 if ($env:GITHUB_ACTIONS -eq 'true')
 {
     Write-Output -InputObject "::add-mask::$($accessToken.token)"
-    "token=$($accessToken.token)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "token=$($accessToken.token)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 }
 elseif (-not [string]::IsNullOrWhiteSpace($env:TF_BUILD))
 {

--- a/.github/actions/mint-github-app-token/action.yml
+++ b/.github/actions/mint-github-app-token/action.yml
@@ -1,0 +1,42 @@
+name: Mint GitHub App Token
+description: >-
+  Mints a short-lived Microsoft Omex installation token using the App private
+  key stored in Azure Key Vault.
+
+inputs:
+  azure-client-id:
+    description: Client ID of the Azure identity federated to GitHub OIDC.
+    required: true
+  azure-tenant-id:
+    description: Azure tenant ID.
+    required: true
+  azure-subscription-id:
+    description: Azure subscription ID.
+    required: true
+  permissions:
+    description: >-
+      JSON object of installation-token permissions, for example
+      '{"contents":"write"}'.
+    required: true
+
+outputs:
+  token:
+    description: The minted GitHub App installation access token.
+    value: ${{ steps.mint.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Azure – Sign-in
+      uses: azure/login@v3
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: App Token – Mint
+      id: mint
+      shell: pwsh
+      run: '& "$Env:GITHUB_ACTION_PATH/New-GitHubAppToken.ps1"'
+      env:
+        GITHUB_APP_PERMISSIONS: ${{ inputs.permissions }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/mint-github-app-token"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/.github/pipelines/github-forward.yml
+++ b/.github/pipelines/github-forward.yml
@@ -40,6 +40,16 @@ extends:
         steps:
         - checkout: self
           clean: true
+        - task: AzureCLI@3
+          displayName: App Token – Mint
+          inputs:
+            connectionType: azureRM
+            azureSubscription: 'OmexGitHubInternal_AdoContributor_UAMI'
+            scriptType: pscore
+            scriptLocation: scriptPath
+            scriptPath: .github/actions/mint-github-app-token/New-GitHubAppToken.ps1
+          env:
+            GITHUB_APP_PERMISSIONS: '{"contents":"read"}'
         - task: PowerShell@2
           displayName: Check New Changes Exist
           inputs:
@@ -52,9 +62,9 @@ extends:
                 Write-Host "##vso[task.setvariable variable=ChangesFound]0"
                 exit 0
               }
-              <#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]#>
-              git remote add omexgithubremote https://$env:omexgitbotexternalpat@github.com/Microsoft/Omex
-              git fetch omexgithubremote
+              $auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$env:GITHUB_APP_TOKEN"))
+              git remote add omexgithubremote https://github.com/Microsoft/Omex
+              git -c "http.extraheader=AUTHORIZATION: basic $auth" fetch omexgithubremote
               $files = git diff --name-only origin/$env:GITHUBBRANCH omexgithubremote/$env:GITHUBBRANCH
               if ($files.length -eq 0) {
                 Write-Host "No changes between 'origin/$env:GITHUBBRANCH' and 'omexgithubremote/$env:GITHUBBRANCH' found."
@@ -66,7 +76,7 @@ extends:
 
               Write-Host "##vso[task.setvariable variable=ChangesFound]$ChangesFound"
           env:
-            omexgitbotexternalpat: $(omexgitbotexternalpat)
+            GITHUB_APP_TOKEN: $(GitHubAppToken)
         - task: PowerShell@2
           displayName: Create Feature Branch For PR Task
           condition: and(succeeded(), ne(variables['ChangesFound'], 0))
@@ -74,11 +84,11 @@ extends:
             targetType: inline
             script: |-
               $commit = $env:GITHUBCOMMIT
-              <#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]#>
-              git fetch https://$env:omexgitbotexternalpat@github.com/Microsoft/Omex $env:GITHUBBRANCH
+              $auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$env:GITHUB_APP_TOKEN"))
+              git -c "http.extraheader=AUTHORIZATION: basic $auth" fetch omexgithubremote $env:GITHUBBRANCH
               git checkout -b feature/github-bridge-forward $commit
           env:
-            omexgitbotexternalpat: $(omexgitbotexternalpat)
+            GITHUB_APP_TOKEN: $(GitHubAppToken)
         - template: pipelines/templates/git-authenticate-steps-wif.yml@OmexPipelines
           parameters:
             azureServiceConnection: 'OmexGitHubInternal_AdoContributor_UAMI'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,25 +27,27 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - name: Checkout – Action
-      uses: actions/checkout@v7
-      with:
-        persist-credentials: false
-        sparse-checkout: .github/actions
-    - name: App Token – Mint
-      id: app-token
-      uses: ./.github/actions/mint-github-app-token
-      with:
-        azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
-        azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-        permissions: '{"pull_requests":"write","statuses":"write"}'
     - name: Checkout
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
+    - name: Checkout – Trusted Action
+      uses: actions/checkout@v7
+      with:
+        path: trusted-action
+        persist-credentials: false
+        ref: ${{ github.event.pull_request.base.sha }}
+        sparse-checkout: .github/actions
+    - name: App Token – Mint
+      id: app-token
+      uses: ./trusted-action/.github/actions/mint-github-app-token
+      with:
+        azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        permissions: '{"pull_requests":"write","statuses":"write"}'
     - name: PR Metrics
       uses: microsoft/PR-Metrics@v1.7.17
       env:
@@ -56,6 +58,9 @@ jobs:
   build:
     if: github.event_name != 'pull_request_target'
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         os: [windows-latest] # [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,28 +8,53 @@ on:
     branches:
       - main
       - release
+  pull_request_target:
+    branches:
+      - main
+      - release
   release:
     types:
       - published
 
+permissions: {}
+
 jobs:
   pr-metrics:
+    if: github.event_name == 'pull_request_target'
     name: PR Metrics
     runs-on: windows-latest
     permissions:
-      pull-requests: write
-      statuses: write
+      contents: read
+      id-token: write
     steps:
+    - name: Checkout – Action
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+        sparse-checkout: .github/actions
+    - name: App Token – Mint
+      id: app-token
+      uses: ./.github/actions/mint-github-app-token
+      with:
+        azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        permissions: '{"pull_requests":"write","statuses":"write"}'
     - name: Checkout
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        persist-credentials: false
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
     - name: PR Metrics
       uses: microsoft/PR-Metrics@v1.7.17
       env:
-        PR_METRICS_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        GITHUB_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        PR_METRICS_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build:
+    if: github.event_name != 'pull_request_target'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/package-update.yml
+++ b/.github/workflows/package-update.yml
@@ -4,22 +4,36 @@ on:
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   run-script-and-pr:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      id-token: write
     steps:
+      - name: Checkout – Action
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions
+
+      - name: App Token – Mint
+        id: app-token
+        uses: ./.github/actions/mint-github-app-token
+        with:
+          azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          permissions: '{"contents":"write","issues":"write","pull_requests":"write"}'
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v6
@@ -70,7 +84,7 @@ jobs:
       - name: Open PR with gh
         if: steps.commit.outputs.has-changes == 'true' && steps.commit.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.CREATE_PACKAGEUPDATE }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: pwsh
         run: |
           git fetch --no-tags --depth=2 origin main


### PR DESCRIPTION
## Purpose
Replace long-lived GitHub PAT authentication with short-lived GitHub App installation tokens backed by Azure Key Vault.

## Impact
GitHub automation now uses scoped, temporary credentials across GitHub Actions and Azure Pipelines, reducing credential exposure and aligning Omex with the established PR Metrics design.