### PR TITLE
Remove client feature overrides

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ This is a collection of shared .NET extensions and utilities for building scalab
 - **Hosting**: Service hosting utilities with environment-specific configurations (`OmexEnvironments`)
 - **Logging**: Centralized logging infrastructure with scrubbing capabilities
 - **Diagnostics.HealthChecks**: Composable health check framework using decorator pattern
-- **FeatureManagement**: Advanced feature flags with A/B testing, experimental features, and query overrides
+- **FeatureManagement**: Advanced feature flags with A/B testing, experimental features, and server-controlled overrides
 - **ServiceFabricGuest.Abstractions**: Service Fabric client wrappers and abstractions
 - **Services.Remoting**: Service Fabric remoting extensions with activity propagation
 - **Testing.Helpers**: Shared testing utilities including `NullableAssert`
@@ -73,7 +73,7 @@ The system supports layered feature resolution with experimental overrides:
 // Always inject IFeatureGatesConsolidator (higher level)
 private readonly IFeatureGatesConsolidator _featureGates;
 
-// Resolution order: Query params → Experiments → Static config
+// Resolution order: Server overrides → Experiments → Static config
 var features = await _featureGates.GetFeatureGatesAsync(filters);
 ```
 
@@ -178,7 +178,7 @@ dotnet pack --no-build --configuration Release
 
 ### Feature Management System
 
-- Layered resolution: Query overrides → Experiments → Static config
+- Layered resolution: Server overrides → Experiments → Static config
 - Support for A/B testing with customer targeting
 - HTTP context integration for web scenarios
 - Frontend feature handling with automatic header processing

--- a/src/FeatureManagement/Constants/RequestParameters.cs
+++ b/src/FeatureManagement/Constants/RequestParameters.cs
@@ -41,23 +41,8 @@ internal static class RequestParameters
 		public const string Campaign = "campaign";
 
 		/// <summary>
-		/// The disabled features query-string parameter.
-		/// </summary>
-		public const string DisabledFeatures = "disabledFeatures";
-
-		/// <summary>
-		/// The enabled features query-string parameter.
-		/// </summary>
-		public const string EnabledFeatures = "enabledFeatures";
-
-		/// <summary>
 		/// The market query-string parameter.
 		/// </summary>
 		public const string Market = "market";
-
-		/// <summary>
-		/// The toggled features query-string parameter.
-		/// </summary>
-		public const string ToggledFeatures = "toggledFeatures";
 	}
 }

--- a/src/FeatureManagement/ExtendedFeatureManager.cs
+++ b/src/FeatureManagement/ExtendedFeatureManager.cs
@@ -7,43 +7,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Microsoft.Omex.Extensions.Abstractions;
-using Microsoft.Omex.Extensions.FeatureManagement.Constants;
-using Microsoft.Omex.Extensions.FeatureManagement.Extensions;
 
 /// <summary>
-/// The extended feature manager provides support for dynamic overriding or toggling of features.
+/// The extended feature manager provides support for server-controlled feature overrides.
 /// </summary>
 /// <param name="featureManager">The feature manger.</param>
-/// <param name="httpContextAccessor">The HTTP context accessor.</param>
 /// <param name="logger">The logger.</param>
 /// <param name="settings">The settings.</param>
 internal sealed class ExtendedFeatureManager(
 	IFeatureManager featureManager,
-	IHttpContextAccessor httpContextAccessor,
 	ILogger<ExtendedFeatureManager> logger,
 	IOptionsMonitor<FeatureOverrideSettings> settings) : IExtendedFeatureManager
 {
-	/// <inheritdoc/>
-	public string DisabledFeatures =>
-		httpContextAccessor.GetParameter(RequestParameters.Query.DisabledFeatures);
-
-	/// <inheritdoc/>
-	public string[] DisabledFeaturesList =>
-		SplitFeatures(DisabledFeatures);
-
-	/// <inheritdoc/>
-	public string EnabledFeatures =>
-		httpContextAccessor.GetParameter(RequestParameters.Query.EnabledFeatures);
-
-	/// <inheritdoc/>
-	public string[] EnabledFeaturesList =>
-		SplitFeatures(EnabledFeatures);
-
 	/// <inheritdoc/>
 	public bool? GetOverride(string feature)
 	{
@@ -53,27 +32,11 @@ internal sealed class ExtendedFeatureManager(
 
 		logger.LogInformation(Tag.Create(), $"{methodName} checking '{{Feature}}'.", feature);
 
-		// Each option below ignores any filters applied to the feature.
-
-		// Checks for the feature in the disabled feature query string, which would always turn the feature off.
-		if (DisabledFeaturesList.Contains(feature, StringComparer.OrdinalIgnoreCase))
-		{
-			logger.LogInformation(Tag.Create(), $"{methodName} returned false for '{{Feature}}' as it is switched off via the query-string parameter '{{DisableFeatures}}'.", feature, RequestParameters.Query.DisabledFeatures);
-			return false;
-		}
-
 		// Checks if the feature is disabled in the settings, which would always turn the feature off.
 		if (settings.CurrentValue.Disabled.Contains(feature, StringComparer.OrdinalIgnoreCase))
 		{
-			logger.LogInformation(Tag.Create(), $"{methodName} returned true for '{{Feature}}' as it is overridden in the {nameof(settings.CurrentValue.Disabled)} setting.", feature);
+			logger.LogInformation(Tag.Create(), $"{methodName} returned false for '{{Feature}}' as it is overridden in the {nameof(settings.CurrentValue.Disabled)} setting.", feature);
 			return false;
-		}
-
-		// Checks for the feature in the enabled feature query string, which would always turn the feature on.
-		if (EnabledFeaturesList.Contains(feature, StringComparer.OrdinalIgnoreCase))
-		{
-			logger.LogInformation(Tag.Create(), $"{methodName} returned true for '{{Feature}}' as it is switched on via the query-string parameter '{{EnabledFeatures}}'.", feature, RequestParameters.Query.EnabledFeatures);
-			return true;
 		}
 
 		// Checks if the feature is enabled in the settings, which would always turn the feature on.
@@ -97,11 +60,6 @@ internal sealed class ExtendedFeatureManager(
 	///<inheritdoc/>
 	public Task<bool> IsEnabledAsync<TContext>(string feature, TContext context) =>
 		IsEnabledInternalAsync(feature, context);
-
-	private static string[] SplitFeatures(string features) =>
-		string.IsNullOrWhiteSpace(features)
-			? []
-			: features.Split(';', StringSplitOptions.RemoveEmptyEntries);
 
 	private async Task<bool> IsEnabledInternalAsync<TContext>(string feature, TContext? context)
 	{

--- a/src/FeatureManagement/FeatureGatesConsolidator.cs
+++ b/src/FeatureManagement/FeatureGatesConsolidator.cs
@@ -25,7 +25,6 @@ using Microsoft.Omex.Extensions.FeatureManagement.Extensions;
 ///
 /// 1. Static feature flags from configuration (appsettings.json)
 /// 2. Dynamic experimental features based on customer targeting
-/// 3. Query-string overrides for testing and debugging
 ///
 /// Key responsibilities:
 /// - Orchestrates calls to IFeatureGatesService for both static and dynamic features

--- a/src/FeatureManagement/FeatureGatesService.cs
+++ b/src/FeatureManagement/FeatureGatesService.cs
@@ -22,14 +22,13 @@ using Microsoft.Omex.Extensions.FeatureManagement.Experimentation;
 /// This implementation of IFeatureGatesService provides the core functionality for managing feature gates and
 /// experiments. It integrates with:
 ///
-/// - IExtendedFeatureManager: For static feature configuration and query-string overrides
+/// - IExtendedFeatureManager: For static feature configuration and server-controlled overrides
 /// - IExperimentManager: For dynamic, customer-targeted experimental features
 /// - ActivitySource: For distributed tracing and observability
 /// - ILogger: For diagnostic logging
 ///
 /// The service handles the "FE_" prefix convention for frontend features, automatically stripping this prefix when
-/// returning feature gates to clients. It also supports feature overrides through query-string parameters, which is
-/// useful for testing and debugging.
+/// returning feature gates to clients.
 /// </remarks>
 /// <param name="activitySource">The activity source for distributed tracing.</param>
 /// <param name="experimentManager">The experiment manager for retrieving experimental features.</param>
@@ -47,14 +46,6 @@ internal sealed class FeatureGatesService(
 	/// </summary>
 	private const string FrontendFeaturePrefix = "FE_";
 
-	/// <inheritdoc />
-	public string RequestedFeatures =>
-		featureManager.EnabledFeatures;
-
-	/// <inheritdoc/>
-	public string BlockedFeatures =>
-		featureManager.DisabledFeatures;
-
 	/// <inheritdoc/>
 	/// <remarks>
 	/// Implementation details:
@@ -62,8 +53,7 @@ internal sealed class FeatureGatesService(
 	/// 2. Filters for features starting with "FE_" prefix (case-insensitive)
 	/// 3. Evaluates each frontend feature using IsEnabledAsync
 	/// 4. Strips the "FE_" prefix when adding to the result dictionary
-	/// 5. Applies overrides from EnabledFeaturesList and DisabledFeaturesList
-	/// 6. Uses TryAdd to prevent duplicate keys (first value wins for case-insensitive duplicates)
+	/// 5. Uses TryAdd to prevent duplicate keys (first value wins for case-insensitive duplicates)
 	/// </remarks>
 	public async Task<IDictionary<string, object>> GetFeatureGatesAsync()
 	{
@@ -80,9 +70,6 @@ internal sealed class FeatureGatesService(
 				featureGates.TryAdd(feature.Substring(FrontendFeaturePrefix.Length), featureFlag);
 			}
 		}
-
-		UpdateFeatureMap(featureGates, featureManager.EnabledFeaturesList, true);
-		UpdateFeatureMap(featureGates, featureManager.DisabledFeaturesList, false);
 
 		activity?.MarkAsSuccess();
 		return featureGates;
@@ -177,7 +164,7 @@ internal sealed class FeatureGatesService(
 	/// <remarks>
 	/// Implementation details and evaluation order:
 	///
-	/// 1. Query-String Override Check (Highest Priority):
+	/// 1. Server Override Check (Highest Priority):
 	///    - Checks IExtendedFeatureManager.GetOverride for explicit overrides
 	///    - If present, immediately returns the override value
 	///    - Sets Activity metadata to "FromOverride_{featureGate}"
@@ -202,11 +189,11 @@ internal sealed class FeatureGatesService(
 			.StartActivity(FeatureManagementActivityNames.FeatureGatesService.IsExperimentApplicableAsync)?
 			.MarkAsExpectedError();
 
-		bool? queryParamOverride = featureManager.GetOverride(featureGate);
-		if (queryParamOverride.HasValue)
+		bool? overrideValue = featureManager.GetOverride(featureGate);
+		if (overrideValue.HasValue)
 		{
 			activity?.SetMetadata($"FromOverride_{featureGate}").MarkAsSuccess();
-			return queryParamOverride.Value;
+			return overrideValue.Value;
 		}
 
 		IDictionary<string, object> features = await GetExperimentalFeaturesAsync(filters, cancellationToken);
@@ -235,31 +222,4 @@ internal sealed class FeatureGatesService(
 		return variable;
 	}
 
-	/// <summary>
-	/// Updates the feature map with the override values from enabled or disabled feature lists.
-	/// </summary>
-	/// <remarks>
-	/// This helper method applies bulk overrides to the feature-gates dictionary. It handles the "FE_" prefix stripping
-	/// for frontend features and directly sets the override value for each feature in the list.
-	///
-	/// Unlike the main feature evaluation, this method uses direct assignment (not
-	/// <see cref="Dictionary{TKey, TValue}.TryAdd(TKey, TValue)"/>), so override values will replace any previously set
-	/// values in the dictionary.
-	/// </remarks>
-	/// <param name="featureGates">The feature-gates dictionary to update.</param>
-	/// <param name="features">The list of feature names to override.</param>
-	/// <param name="overrideValue">The value to set for all features in the list (<c>true</c> for enabled, <c>false</c> for disabled).</param>
-	private static void UpdateFeatureMap(Dictionary<string, object> featureGates, IEnumerable<string> features, bool overrideValue)
-	{
-		foreach (string feature in features)
-		{
-			string adjustedFeature = feature;
-			if (feature.StartsWith(FrontendFeaturePrefix, StringComparison.OrdinalIgnoreCase))
-			{
-				adjustedFeature = feature.Substring(FrontendFeaturePrefix.Length);
-			}
-
-			featureGates[adjustedFeature] = overrideValue;
-		}
-	}
 }

--- a/src/FeatureManagement/FeatureGatesService.cs
+++ b/src/FeatureManagement/FeatureGatesService.cs
@@ -221,5 +221,4 @@ internal sealed class FeatureGatesService(
 
 		return variable;
 	}
-
 }

--- a/src/FeatureManagement/Filters/ToggleFilter.cs
+++ b/src/FeatureManagement/Filters/ToggleFilter.cs
@@ -4,25 +4,19 @@
 namespace Microsoft.Omex.Extensions.FeatureManagement.Filters;
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Microsoft.Omex.Extensions.Abstractions;
-using Microsoft.Omex.Extensions.FeatureManagement.Constants;
-using Microsoft.Omex.Extensions.FeatureManagement.Extensions;
 
 /// <summary>
 /// The filter to allow a feature to be toggled to the enabled state while preserving the evaluation of other filters on the feature.
 /// </summary>
-/// <param name="httpContextAccessor">The HTTP context accessor.</param>
 /// <param name="logger">The logger.</param>
 /// <param name="settings">The settings.</param>
 [FilterAlias("Toggle")]
 public sealed class ToggleFilter(
-	IHttpContextAccessor httpContextAccessor,
 	ILogger<ToggleFilter> logger,
 	IOptionsMonitor<FeatureOverrideSettings> settings) : IFeatureFilter
 {
@@ -35,10 +29,6 @@ public sealed class ToggleFilter(
 	}
 
 	private bool Evaluate(FeatureFilterEvaluationContext context)
-	{
-		string toggledFeatures = httpContextAccessor.GetParameter(RequestParameters.Query.ToggledFeatures);
-		string[] toggledFeaturesList = toggledFeatures.Split(';', StringSplitOptions.RemoveEmptyEntries);
-		return toggledFeaturesList.Contains(context.FeatureName, StringComparer.OrdinalIgnoreCase) ||
-			Array.Exists(settings.CurrentValue.Toggled, f => string.Equals(f, context.FeatureName, StringComparison.OrdinalIgnoreCase));
-	}
+		=> Array.Exists(settings.CurrentValue.Toggled, feature =>
+			string.Equals(feature, context.FeatureName, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/FeatureManagement/IExtendedFeatureManager.cs
+++ b/src/FeatureManagement/IExtendedFeatureManager.cs
@@ -6,34 +6,12 @@ namespace Microsoft.Omex.Extensions.FeatureManagement;
 using Microsoft.FeatureManagement;
 
 /// <summary>
-/// The extended feature manager provides support for dynamic overriding or toggling of features.
+/// The extended feature manager provides support for server-controlled overriding or toggling of features.
 /// </summary>
-/// <remarks>This extends feature flag management by supporting dynamic, per-request feature overrides using
-/// query-string parameters and configuration settings. This is particularly useful for scenarios where you want to
-/// enable or disable features for specific requests, such as for testing, gradual rollouts, or customer-specific
-/// toggling.</remarks>
+/// <remarks>Request-driven feature overrides are not supported. Use <see cref="FeatureOverrideSettings"/> for
+/// server-controlled overrides.</remarks>
 public interface IExtendedFeatureManager : IFeatureManager
 {
-	/// <summary>
-	/// Gets the list of features which are explicitly disabled for this request as a <see cref="string"/>.
-	/// </summary>
-	string DisabledFeatures { get; }
-
-	/// <summary>
-	/// Gets the list of features which are explicitly disabled for this request as a <see cref="string"/> array.
-	/// </summary>
-	string[] DisabledFeaturesList { get; }
-
-	/// <summary>
-	/// Gets the list of features which are explicitly enabled for this request as a <see cref="string"/>.
-	/// </summary>
-	string EnabledFeatures { get; }
-
-	/// <summary>
-	/// Gets the list of features which are explicitly enabled for this request as a <see cref="string"/> array.
-	/// </summary>
-	string[] EnabledFeaturesList { get; }
-
 	/// <summary>
 	/// Gets the override value for a feature or <c>null</c> if none exists.
 	/// </summary>

--- a/src/FeatureManagement/IFeatureGatesConsolidator.cs
+++ b/src/FeatureManagement/IFeatureGatesConsolidator.cs
@@ -18,7 +18,6 @@ using Microsoft.AspNetCore.Http;
 ///
 /// 1. Static feature flags from configuration (appsettings.json)
 /// 2. Dynamic experimental features based on customer targeting
-/// 3. Query-string overrides for testing and debugging
 ///
 /// The consolidator requires an active HTTP context to operate, as it extracts partner information and other
 /// request-specific data from HTTP headers. Experimental features take precedence over static configuration when
@@ -49,7 +48,7 @@ public interface IFeatureGatesConsolidator
 	/// The consolidation process ensures that:
 	/// - Customers in experiments get their assigned treatments
 	/// - Customers not in experiments fall back to static configuration
-	/// - Override settings (from query strings) are respected
+	/// - Server-controlled override settings are respected
 	/// </remarks>
 	/// <param name="filters"> The experiment filters to apply when retrieving experimental features.</param>
 	/// <param name="headerPrefix">

--- a/src/FeatureManagement/IFeatureGatesService.cs
+++ b/src/FeatureManagement/IFeatureGatesService.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 /// a customer, supporting both static feature flags and dynamic experimentation scenarios.
 ///
 /// The service integrates with both a feature manager (for static configuration-based features) and an experiment
-/// manager (for dynamic, customer-targeted features). Features can be overridden via query-string parameters.
+/// manager (for dynamic, customer-targeted features). Features can be overridden through server configuration.
 ///
 /// Features prefixed with "FE_" are treated as frontend features, and this prefix is automatically stripped when
 /// returning feature-gate values to clients.
@@ -25,39 +25,11 @@ using System.Threading.Tasks;
 public interface IFeatureGatesService
 {
 	/// <summary>
-	/// Gets the list of features which are explicitly allowed for this request as a semicolon-delimited <see cref="string"/>.
-	/// </summary>
-	/// <remarks>
-	/// This property returns features that have been explicitly enabled via query-string overrides or configuration
-	/// settings. The format is a semicolon-delimited string (e.g., "Feature1;Feature2;FE_Feature3"). Frontend features
-	/// may include the "FE_" prefix in this list.
-	/// </remarks>
-	/// <example>
-	/// Example value: "FE_NewUI;FE_BetaFeature;BackendOptimization"
-	/// </example>
-	string RequestedFeatures { get; }
-
-	/// <summary>
-	/// Gets the list of features which are explicitly blocked for this request as a semicolon-delimited <see cref="string"/>.
-	/// </summary>
-	/// <remarks>
-	/// This property returns features that have been explicitly disabled via query-string overrides or configuration
-	/// settings. The format is a semicolon-delimited string (e.g., "Feature1;Feature2"). Frontend features may include
-	/// the "FE_" prefix in this list.
-	/// </remarks>
-	/// <example>
-	/// Example value: "FE_LegacyUI;DeprecatedFeature"
-	/// </example>
-	string BlockedFeatures { get; }
-
-	/// <summary>
 	/// Gets all the feature gates and their values.
 	/// </summary>
 	/// <remarks>
-	/// This method retrieves all configured feature gates, including both static features from configuration and any
-	/// overrides from query-string parameters. Frontend features (those prefixed with "FE_") will have their prefix
-	/// removed in the returned dictionary. The method also applies any explicit enable/disable overrides from the
-	/// RequestedFeatures and BlockedFeatures lists.
+	/// This method retrieves all configured feature gates. Frontend features (those prefixed with "FE_") will have
+	/// their prefix removed in the returned dictionary.
 	///
 	/// The returned dictionary uses case-insensitive keys to prevent duplicate features with different casing. Values
 	/// can be Boolean (true/false) or other object types depending on the feature configuration.
@@ -179,7 +151,7 @@ public interface IFeatureGatesService
 	/// <remarks>
 	/// This method provides a comprehensive check for feature availability by evaluating in the following order:
 	///
-	/// 1. Query-string overrides (via IExtendedFeatureManager.GetOverride) - Highest priority
+	/// 1. Server-controlled overrides (via IExtendedFeatureManager.GetOverride) - Highest priority
 	/// 2. Experiment allocation based on filters - Returns true for any non-empty, non-false value
 	/// 3. Static feature configuration (via IsFeatureGateApplicableAsync) - Fallback
 	///
@@ -189,8 +161,8 @@ public interface IFeatureGatesService
 	/// - Other string values: Treated as treatment allocation (returns true)
 	/// - Empty/whitespace values: Falls back to static configuration
 	///
-	/// This cascading evaluation ensures features can be controlled at multiple levels, from temporary overrides for
-	/// testing to experiment-based rollouts to global configuration.
+	/// This cascading evaluation ensures features can be controlled at multiple levels, from server overrides to
+	/// experiment-based rollouts to global configuration.
 	/// </remarks>
 	/// <param name="featureGate">The name of the feature gate to check.</param>
 	/// <param name="filters">The experiment filters to apply for determining allocation.</param>
@@ -209,7 +181,7 @@ public interface IFeatureGatesService
 	/// bool showFeature = await IsExperimentApplicableAsync("NewFeature", filters, cancellationToken);
 	///
 	/// // The method will check:
-	/// // 1. Query-string override (?features=NewFeature or ?blockedFeatures=NewFeature)
+	/// // 1. Server-controlled override
 	/// // 2. Experiment allocation for customer 12345
 	/// // 3. Static configuration in appsettings.json
 	/// </example>

--- a/src/FeatureManagement/README.md
+++ b/src/FeatureManagement/README.md
@@ -11,7 +11,7 @@ Built on top of [Microsoft's Feature Management library](https://github.com/micr
 - **Feature Flags**: Toggle features on/off without code deployment
 - **A/B Testing**: Run experiments with customer targeting
 - **Multiple Filter Types**: Time window, percentage, market, campaign, and more
-- **Runtime Overrides**: Temporarily enable/disable features via query parameters
+- **Server-Controlled Overrides**: Force features on/off through configuration
 - **Frontend Support**: Automatic handling of frontend-specific features
 - **Custom Filters**: Extensible filter system for custom logic
 - **Comprehensive Observability**: Built-in logging and distributed tracing
@@ -52,9 +52,9 @@ It is recommended to use `IFeatureGatesConsolidator` where possible to simplify 
 
 This implementation uses a layered approach to feature resolution, allowing for multiple sources of truth. The order of precedence is as follows:
 
-1. **Query-String Overrides** (Highest Priority)
-   - `?features=Feature1;Feature2`: Enable features
-   - `?blockedFeatures=Feature3`: Disable features
+1. **Server-Controlled Overrides** (Highest Priority)
+   - `FeatureOverrideSettings.Enabled`: Enable features
+   - `FeatureOverrideSettings.Disabled`: Disable features
 1. **Experimental Features**
    - Customer-targeted experiments
    - A/B test allocations
@@ -252,9 +252,7 @@ How it works:
 
 - Define your complete feature logic in `appsettings.json` with all necessary filters (time windows, percentages, markets, etc).
 - Add the `Toggle` filter to keep the feature disabled by default.
-- Activate the feature at runtime through:
-  - The `toggledFeatures` query-string parameter (semicolon-separated list).
-  - Or your experimentation service (see [Experimental Features](#experimental-features)).
+- Activate the feature through the server-controlled `FeatureOverrideSettings.Toggled` configuration.
 
 This approach allows you to specify and deploy complex feature logic that could not be defined through query-string parameters alone. When activated, the feature evaluates all its configured filters normally – the toggle simply acts as a main switch.
 

--- a/src/FeatureManagement/README.md
+++ b/src/FeatureManagement/README.md
@@ -62,8 +62,6 @@ This implementation uses a layered approach to feature resolution, allowing for 
    - Features defined in `appsettings.json`
    - Default values
 
-HTTP query-string parameters and request headers cannot override feature states.
-
 ### Experimental Features
 
 If you have an experimentation service available, you can make runtime configuration changes to override the static configuration. You will need to inherit from [`IExperimentManager`](Experimentation/IExperimentManager.cs) and pass the class when calling `ConfigureFeatureManagement()`. By default, no experimentation service will be used.

--- a/src/FeatureManagement/README.md
+++ b/src/FeatureManagement/README.md
@@ -62,6 +62,8 @@ This implementation uses a layered approach to feature resolution, allowing for 
    - Features defined in `appsettings.json`
    - Default values
 
+HTTP query-string parameters and request headers cannot override feature states.
+
 ### Experimental Features
 
 If you have an experimentation service available, you can make runtime configuration changes to override the static configuration. You will need to inherit from [`IExperimentManager`](Experimentation/IExperimentManager.cs) and pass the class when calling `ConfigureFeatureManagement()`. By default, no experimentation service will be used.
@@ -254,7 +256,7 @@ How it works:
 - Add the `Toggle` filter to keep the feature disabled by default.
 - Activate the feature through the server-controlled `FeatureOverrideSettings.Toggled` configuration.
 
-This approach allows you to specify and deploy complex feature logic that could not be defined through query-string parameters alone. When activated, the feature evaluates all its configured filters normally – the toggle simply acts as a main switch.
+This approach allows you to deploy complex feature logic in advance, then activate it through server-controlled configuration. When activated, the feature evaluates all its configured filters normally – the toggle acts as a main switch.
 
 ```JSON
 "FeatureToggleA": {

--- a/src/FeatureManagement/README.md
+++ b/src/FeatureManagement/README.md
@@ -70,6 +70,8 @@ If you have an experimentation service available, you can make runtime configura
 
 `FeatureOverrideSettings.Disabled` and `FeatureOverrideSettings.Enabled` turn a feature on or off regardless of the filters. If a feature is added to both settings, `FeatureOverrideSettings.Disabled` takes precedence.
 
+Override entries must use the complete configured feature key, including the `FE_` prefix for frontend features. Matching is case-insensitive.
+
 `FeatureOverrideSettings.Toggled` allows the enablement of a feature committed as disabled but with the `Toggle` filter present. On activation, this will evaluate the applied filters.
 
 ### Static Configuration

--- a/tests/FeatureManagement.UnitTests/ExtendedFeatureManagerTests.cs
+++ b/tests/FeatureManagement.UnitTests/ExtendedFeatureManagerTests.cs
@@ -257,5 +257,4 @@ public sealed class ExtendedFeatureManagerTests
 	}
 
 	#endregion
-
 }

--- a/tests/FeatureManagement.UnitTests/ExtendedFeatureManagerTests.cs
+++ b/tests/FeatureManagement.UnitTests/ExtendedFeatureManagerTests.cs
@@ -9,14 +9,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Microsoft.FeatureManagement;
 using Microsoft.Omex.Extensions.FeatureManagement;
-using Microsoft.Omex.Extensions.FeatureManagement.Constants;
-using Microsoft.Omex.Extensions.Testing.Helpers.HttpContext;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -26,7 +22,6 @@ public sealed class ExtendedFeatureManagerTests
 	public TestContext TestContext { get; set; }
 
 	private readonly Mock<IFeatureManager> m_featureManagerMock;
-	private HttpContextAccessor m_httpContextAccessorMock;
 	private readonly Mock<ILogger<ExtendedFeatureManager>> m_loggerMock;
 	private readonly Mock<IOptionsMonitor<FeatureOverrideSettings>> m_settingsMock;
 	private readonly ExtendedFeatureManager m_extendedFeatureManager;
@@ -35,7 +30,6 @@ public sealed class ExtendedFeatureManagerTests
 	public ExtendedFeatureManagerTests()
 	{
 		m_featureManagerMock = new();
-		m_httpContextAccessorMock = HttpContextAccessorFactory.Create();
 		m_loggerMock = new();
 		m_settingsMock = new();
 
@@ -48,138 +42,9 @@ public sealed class ExtendedFeatureManagerTests
 
 		m_extendedFeatureManager = new(
 			m_featureManagerMock.Object,
-			m_httpContextAccessorMock,
 			m_loggerMock.Object,
 			m_settingsMock.Object);
 	}
-
-	#region DisabledFeatures
-
-	[TestMethod]
-	public void DisabledFeatures_WhenCalled_ReturnsValueFromHttpContextAccessor()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;feature2");
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, expectedValue);
-
-		// ACT
-		string result = m_extendedFeatureManager.DisabledFeatures;
-
-		// ASSERT
-		Assert.AreEqual(expectedValue.ToString(), result);
-	}
-
-	#endregion
-
-	#region DisabledFeaturesList
-
-	[TestMethod]
-	public void DisabledFeaturesList_WithNoFeatures_ReturnsEmptyArray()
-	{
-		// ARRANGE
-		StringValues expectedValue = new();
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.DisabledFeaturesList;
-
-		// ASSERT
-		Assert.IsEmpty(result);
-	}
-
-	[TestMethod]
-	public void DisabledFeaturesList_WithMultipleFeatures_SplitsStringCorrectly()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;feature2;feature3");
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.DisabledFeaturesList;
-
-		// ASSERT
-		CollectionAssert.AreEqual(s_expected, result);
-	}
-
-	[TestMethod]
-	public void DisabledFeaturesList_WithEmptyFeatures_SplitsStringCorrectly()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;;feature2;;feature3;");
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.DisabledFeaturesList;
-
-		// ASSERT
-		CollectionAssert.AreEqual(s_expected, result);
-	}
-
-	#endregion
-
-	#region EnabledFeatures
-
-	[TestMethod]
-	public void EnabledFeatures_WhenCalled_ReturnsValueFromHttpContextAccessor()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;feature2");
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, expectedValue);
-
-		// ACT
-		string result = m_extendedFeatureManager.EnabledFeatures;
-
-		// ASSERT
-		Assert.AreEqual(expectedValue.ToString(), result);
-	}
-
-	#endregion
-
-	#region EnabledFeaturesList
-
-	[TestMethod]
-	public void EnabledFeaturesList_WithNoFeatures_ReturnsEmptyArray()
-	{
-		// ARRANGE
-		StringValues expectedValue = new();
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.EnabledFeaturesList;
-
-		// ASSERT
-		Assert.IsEmpty(result);
-	}
-
-	[TestMethod]
-	public void EnabledFeaturesList_WithMultipleFeatures_SplitsStringCorrectly()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;feature2;feature3");
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.EnabledFeaturesList;
-
-		// ASSERT
-		CollectionAssert.AreEqual(s_expected, result);
-	}
-
-	[TestMethod]
-	public void EnabledFeaturesList_WithEmptyFeatures_SplitsStringCorrectly()
-	{
-		// ARRANGE
-		StringValues expectedValue = new("feature1;;feature2;;feature3;");
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, expectedValue);
-
-		// ACT
-		string[] result = m_extendedFeatureManager.EnabledFeaturesList;
-
-		// ASSERT
-		CollectionAssert.AreEqual(s_expected, result);
-	}
-
-	#endregion
 
 	#region GetOverride
 
@@ -197,23 +62,6 @@ public sealed class ExtendedFeatureManagerTests
 	}
 
 	[TestMethod]
-	[DataRow("requestedFeature")]
-	[DataRow("REQUESTEDFEATURE")] // Case-insensitive
-	public void GetOverride_WhenFeatureInEnabledFeatures_ReturnsTrueWhen(string featureName)
-	{
-		// ARRANGE
-		const string requestedFeature = "requestedFeature";
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, requestedFeature);
-
-		// ACT
-		bool? result = m_extendedFeatureManager.GetOverride(featureName);
-
-		// ASSERT
-		Assert.IsTrue(result.HasValue);
-		Assert.IsTrue(result.Value);
-	}
-
-	[TestMethod]
 	[DataRow("EnabledFeature1")]
 	[DataRow("enabledfeature2")] // Case-insensitive
 	public void GetOverride_WhenFeatureInOverrideEnabled_ReturnsTrue(string featureName)
@@ -227,23 +75,6 @@ public sealed class ExtendedFeatureManagerTests
 		// ASSERT
 		Assert.IsTrue(result.HasValue);
 		Assert.IsTrue(result.Value);
-	}
-
-	[TestMethod]
-	[DataRow("blockedFeature")]
-	[DataRow("BLOCKEDFEATURE")] // Case-insensitive
-	public void GetOverride_WhenFeatureInDisabledFeatures_ReturnsFalse(string featureName)
-	{
-		// ARRANGE
-		const string blockedFeature = "blockedFeature";
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, blockedFeature);
-
-		// ACT
-		bool? result = m_extendedFeatureManager.GetOverride(featureName);
-
-		// ASSERT
-		Assert.IsTrue(result.HasValue);
-		Assert.IsFalse(result.Value);
 	}
 
 	[TestMethod]
@@ -331,36 +162,6 @@ public sealed class ExtendedFeatureManagerTests
 	}
 
 	[TestMethod]
-	public async Task IsEnabledAsync_WhenFeatureInEnabledFeatures_ReturnsTrue()
-	{
-		// ARRANGE
-		const string featureName = "TestFeature";
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, featureName);
-
-		// ACT
-		bool result = await m_extendedFeatureManager.IsEnabledAsync(featureName);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		m_featureManagerMock.Verify(m => m.IsEnabledAsync(It.IsAny<string>()), Times.Never);
-	}
-
-	[TestMethod]
-	public async Task IsEnabledAsync_WhenFeatureInDisabledFeatures_ReturnsFalse()
-	{
-		// ARRANGE
-		const string featureName = "TestFeature";
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, featureName);
-
-		// ACT
-		bool result = await m_extendedFeatureManager.IsEnabledAsync(featureName);
-
-		// ASSERT
-		Assert.IsFalse(result);
-		m_featureManagerMock.Verify(m => m.IsEnabledAsync(It.IsAny<string>()), Times.Never);
-	}
-
-	[TestMethod]
 	public async Task IsEnabledAsync_WhenFeatureInOverrideEnabled_ReturnsTrue()
 	{
 		// ARRANGE
@@ -426,38 +227,6 @@ public sealed class ExtendedFeatureManagerTests
 	}
 
 	[TestMethod]
-	public async Task IsEnabledAsyncWithContext_WhenFeatureInEnabledFeatures_ReturnsTrue()
-	{
-		// ARRANGE
-		const string featureName = "TestFeature";
-		const int context = 0;
-		InitializeHttpContextAccessor(RequestParameters.Query.EnabledFeatures, featureName);
-
-		// ACT
-		bool result = await m_extendedFeatureManager.IsEnabledAsync(featureName, context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		m_featureManagerMock.Verify(m => m.IsEnabledAsync(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
-	}
-
-	[TestMethod]
-	public async Task IsEnabledAsyncWithContext_WhenFeatureInDisabledFeatures_ReturnsFalse()
-	{
-		// ARRANGE
-		const string featureName = "TestFeature";
-		const int context = 0;
-		InitializeHttpContextAccessor(RequestParameters.Query.DisabledFeatures, featureName);
-
-		// ACT
-		bool result = await m_extendedFeatureManager.IsEnabledAsync(featureName, context);
-
-		// ASSERT
-		Assert.IsFalse(result);
-		m_featureManagerMock.Verify(m => m.IsEnabledAsync(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
-	}
-
-	[TestMethod]
 	public async Task IsEnabledAsyncWithContext_WhenFeatureInOverrideEnabled_ReturnsTrue()
 	{
 		// ARRANGE
@@ -489,13 +258,4 @@ public sealed class ExtendedFeatureManagerTests
 
 	#endregion
 
-	private void InitializeHttpContextAccessor(string paramName, StringValues paramValue)
-	{
-		Dictionary<string, StringValues> queryParameters = new(StringComparer.Ordinal)
-		{
-			{ paramName, paramValue },
-		};
-
-		m_httpContextAccessorMock = HttpContextAccessorFactory.Create(queryParameters);
-	}
 }

--- a/tests/FeatureManagement.UnitTests/FeatureGatesServiceTests.cs
+++ b/tests/FeatureManagement.UnitTests/FeatureGatesServiceTests.cs
@@ -42,40 +42,6 @@ public sealed class FeatureGatesServiceTests
 			m_loggerMock.Object);
 	}
 
-	#region RequestedFeatures
-
-	[TestMethod]
-	public void RequestedFeatures_WhenCalled_ReturnsFromFeatureManager()
-	{
-		// ARRANGE
-		m_featureManagerMock.Setup(m => m.EnabledFeatures).Returns("FE_Test1;FE_Test2");
-
-		// ACT
-		string result = m_featureGatesService.RequestedFeatures;
-
-		// ASSERT
-		Assert.AreEqual("FE_Test1;FE_Test2", result);
-	}
-
-	#endregion
-
-	#region BlockedFeatures
-
-	[TestMethod]
-	public void BlockedFeatures_WhenCalled_ReturnsFromFeatureManager()
-	{
-		// ARRANGE
-		m_featureManagerMock.Setup(m => m.DisabledFeatures).Returns("FE_Blocked1");
-
-		// ACT
-		string result = m_featureGatesService.BlockedFeatures;
-
-		// ASSERT
-		Assert.AreEqual("FE_Blocked1", result);
-	}
-
-	#endregion
-
 	#region GetFeatureGatesAsync
 
 	[TestMethod]
@@ -86,16 +52,14 @@ public sealed class FeatureGatesServiceTests
 		m_featureManagerMock.Setup(m => m.GetFeatureNamesAsync()).Returns(AsyncEnumerable.ToAsyncEnumerable(features));
 		m_featureManagerMock.Setup(m => m.IsEnabledAsync("FE_Test1")).ReturnsAsync(true);
 		m_featureManagerMock.Setup(m => m.IsEnabledAsync("FE_Test2")).ReturnsAsync(false);
-		m_featureManagerMock.Setup(m => m.EnabledFeaturesList).Returns(["FE_Test2"]);
-		m_featureManagerMock.Setup(m => m.DisabledFeaturesList).Returns(["FE_Test1"]);
 
 		// ACT
 		IDictionary<string, object> result = await m_featureGatesService.GetFeatureGatesAsync();
 
 		// ASSERT
 		Assert.HasCount(2, result);
-		Assert.IsFalse((bool)result["Test1"]); // DisabledFeaturesList overrides to false.
-		Assert.IsTrue((bool)result["Test2"]);  // EnabledFeaturesList overrides to true.
+		Assert.IsTrue((bool)result["Test1"]);
+		Assert.IsFalse((bool)result["Test2"]);
 	}
 
 	[TestMethod]
@@ -104,8 +68,6 @@ public sealed class FeatureGatesServiceTests
 		// ARRANGE
 		List<string> features = ["Other1", "Other2"];
 		m_featureManagerMock.Setup(m => m.GetFeatureNamesAsync()).Returns(AsyncEnumerable.ToAsyncEnumerable(features));
-		m_featureManagerMock.Setup(m => m.EnabledFeaturesList).Returns([]);
-		m_featureManagerMock.Setup(m => m.DisabledFeaturesList).Returns([]);
 
 		// ACT
 		IDictionary<string, object> result = await m_featureGatesService.GetFeatureGatesAsync();
@@ -122,8 +84,6 @@ public sealed class FeatureGatesServiceTests
 		m_featureManagerMock.Setup(m => m.GetFeatureNamesAsync()).Returns(AsyncEnumerable.ToAsyncEnumerable(features));
 		m_featureManagerMock.Setup(m => m.IsEnabledAsync("FE_Test1")).ReturnsAsync(true);
 		m_featureManagerMock.Setup(m => m.IsEnabledAsync("fe_test1")).ReturnsAsync(false);
-		m_featureManagerMock.Setup(m => m.EnabledFeaturesList).Returns([]);
-		m_featureManagerMock.Setup(m => m.DisabledFeaturesList).Returns([]);
 
 		// ACT
 		IDictionary<string, object> result = await m_featureGatesService.GetFeatureGatesAsync();
@@ -131,42 +91,6 @@ public sealed class FeatureGatesServiceTests
 		// ASSERT
 		Assert.HasCount(1, result);
 		Assert.IsTrue((bool)result["Test1"]); // First value wins due to TryAdd.
-	}
-
-	[TestMethod]
-	public async Task GetFeatureGatesAsync_WithEnabledFeaturesListWithoutPrefix_HandlesCorrectly()
-	{
-		// ARRANGE
-		List<string> features = [];
-		m_featureManagerMock.Setup(m => m.GetFeatureNamesAsync()).Returns(AsyncEnumerable.ToAsyncEnumerable(features));
-		m_featureManagerMock.Setup(m => m.EnabledFeaturesList).Returns(["Test1", "FE_Test2"]);
-		m_featureManagerMock.Setup(m => m.DisabledFeaturesList).Returns([]);
-
-		// ACT
-		IDictionary<string, object> result = await m_featureGatesService.GetFeatureGatesAsync();
-
-		// ASSERT
-		Assert.HasCount(2, result);
-		Assert.IsTrue((bool)result["Test1"]);
-		Assert.IsTrue((bool)result["Test2"]);
-	}
-
-	[TestMethod]
-	public async Task GetFeatureGatesAsync_WithDisabledFeaturesListWithoutPrefix_HandlesCorrectly()
-	{
-		// ARRANGE
-		List<string> features = [];
-		m_featureManagerMock.Setup(m => m.GetFeatureNamesAsync()).Returns(AsyncEnumerable.ToAsyncEnumerable(features));
-		m_featureManagerMock.Setup(m => m.EnabledFeaturesList).Returns([]);
-		m_featureManagerMock.Setup(m => m.DisabledFeaturesList).Returns(["Test1", "FE_Test2"]);
-
-		// ACT
-		IDictionary<string, object> result = await m_featureGatesService.GetFeatureGatesAsync();
-
-		// ASSERT
-		Assert.HasCount(2, result);
-		Assert.IsFalse((bool)result["Test1"]);
-		Assert.IsFalse((bool)result["Test2"]);
 	}
 
 	#endregion

--- a/tests/FeatureManagement.UnitTests/Filters/ToggleFilterTests.cs
+++ b/tests/FeatureManagement.UnitTests/Filters/ToggleFilterTests.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Omex.Extensions.FeatureManagement.UnitTests.Filters;
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
@@ -18,26 +17,21 @@ using Moq;
 public sealed class ToggleFilterTests
 {
 	private const string TestFeatureName = "TestFeature";
-	private readonly Mock<IHttpContextAccessor> m_httpContextAccessorMock;
 	private readonly Mock<ILogger<ToggleFilter>> m_loggerMock;
 	private readonly Mock<IOptionsMonitor<FeatureOverrideSettings>> m_settingsMock;
 	private readonly ToggleFilter m_filter;
 	private readonly FeatureFilterEvaluationContext m_context;
 	private readonly FeatureOverrideSettings m_featureOverrideSettings;
-	private readonly DefaultHttpContext m_httpContext;
 
 	public ToggleFilterTests()
 	{
-		m_httpContextAccessorMock = new();
 		m_loggerMock = new();
 		m_settingsMock = new();
 		m_featureOverrideSettings = new();
-		m_httpContext = new();
 
 		m_settingsMock.Setup(s => s.CurrentValue).Returns(m_featureOverrideSettings);
-		m_httpContextAccessorMock.Setup(h => h.HttpContext).Returns(m_httpContext);
 
-		m_filter = new(m_httpContextAccessorMock.Object, m_loggerMock.Object, m_settingsMock.Object);
+		m_filter = new(m_loggerMock.Object, m_settingsMock.Object);
 		m_context = new()
 		{
 			FeatureName = TestFeatureName,
@@ -45,34 +39,6 @@ public sealed class ToggleFilterTests
 	}
 
 	#region EvaluateAsync
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenFeatureIsToggledInQueryString_ReturnsTrue()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures={TestFeatureName}");
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenFeatureIsToggledInQueryStringWithDifferentCase_ReturnsTrue()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures={TestFeatureName.ToUpperInvariant()}");
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
 
 	[TestMethod]
 	public async Task EvaluateAsync_WhenFeatureIsToggledInSettings_ReturnsTrue()
@@ -117,34 +83,6 @@ public sealed class ToggleFilterTests
 	}
 
 	[TestMethod]
-	public async Task EvaluateAsync_WhenHttpContextIsNull_ReturnsFalse()
-	{
-		// ARRANGE
-		m_httpContextAccessorMock.Setup(h => h.HttpContext).Returns((HttpContext?)null);
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsFalse(result);
-		VerifyLogging(false);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenMultipleFeaturesToggledInQueryString_FindsCorrectFeature()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures=OtherFeature;{TestFeatureName};AnotherFeature");
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
-
-	[TestMethod]
 	public async Task EvaluateAsync_WhenMultipleFeaturesInSettingsArray_FindsCorrectFeature()
 	{
 		// ARRANGE
@@ -159,65 +97,6 @@ public sealed class ToggleFilterTests
 	}
 
 	[TestMethod]
-	public async Task EvaluateAsync_WhenFeatureInBothQueryStringAndSettings_ReturnsTrue()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures={TestFeatureName}");
-		m_featureOverrideSettings.Toggled = [TestFeatureName];
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenFeatureNotInQueryStringButInSettings_ReturnsTrue()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new("?toggledFeatures=OtherFeature");
-		m_featureOverrideSettings.Toggled = [TestFeatureName];
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenFeatureInQueryStringButNotInSettings_ReturnsTrue()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures={TestFeatureName}");
-		m_featureOverrideSettings.Toggled = ["OtherFeature"];
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenEmptyQueryStringParameter_ReturnsFalse()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new("?toggledFeatures=");
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsFalse(result);
-		VerifyLogging(false);
-	}
-
-	[TestMethod]
 	public async Task EvaluateAsync_WhenEmptySettingsArray_ReturnsFalse()
 	{
 		// ARRANGE
@@ -229,20 +108,6 @@ public sealed class ToggleFilterTests
 		// ASSERT
 		Assert.IsFalse(result);
 		VerifyLogging(false);
-	}
-
-	[TestMethod]
-	public async Task EvaluateAsync_WhenQueryStringHasMultipleSeparators_ParsesCorrectly()
-	{
-		// ARRANGE
-		m_httpContext.Request.QueryString = new($"?toggledFeatures=;;{TestFeatureName};;OtherFeature;;");
-
-		// ACT
-		bool result = await m_filter.EvaluateAsync(m_context);
-
-		// ASSERT
-		Assert.IsTrue(result);
-		VerifyLogging(true);
 	}
 
 	#endregion


### PR DESCRIPTION
## Purpose
Remove unauthenticated request controls that allowed callers to force feature states and bypass configured evaluation.

## Impact
Feature state is now controlled only by server configuration, experiments, and existing filters. This intentionally breaks consumers of the retired request override API.