### PR TITLE
XS✔ ◾ Fix NonInteractive Invoke-WebRequest failure in GitHub WebHook pipeline

### DIFF
--- a/.github/pipelines/github-webhook.yml
+++ b/.github/pipelines/github-webhook.yml
@@ -78,7 +78,7 @@ extends:
                   "Content-Type" = "application/json";
                   "Authorization" = "Bearer $env:UAMI_TOKEN"
               }
-              $Response = Invoke-WebRequest -Method 'POST' -Body $Body -Uri "https://office.visualstudio.com/OC/_apis/build/builds?api-version=7.1" -Headers $headers
+              $Response = Invoke-WebRequest -UseBasicParsing -Method 'POST' -Body $Body -Uri "https://office.visualstudio.com/OC/_apis/build/builds?api-version=7.1" -Headers $headers
 
               if ($Response.StatusCode -ne 200) {
                       Write-Warning "Non-200 status code encountered."


### PR DESCRIPTION
Windows PowerShell 5.1's Invoke-WebRequest parses responses with the IE COM engine. On the hosted windows-2022 agent IE first-run configuration has not been completed, so parsing tries to prompt and throws PSInvalidOperationException in NonInteractive mode. The POST itself succeeds and the forward build is queued, but the task still fails.

Add -UseBasicParsing to skip the IE DOM parser. StatusCode, Headers and RawContent used later in the script are unaffected.